### PR TITLE
bump defichain-dependencies to always stay on bleeding edge

### DIFF
--- a/.github/workflows/defichain-dependencies.yml
+++ b/.github/workflows/defichain-dependencies.yml
@@ -24,6 +24,7 @@ jobs:
           @defichain/jellyfish-transaction-builder \
           @defichain/jellyfish-wallet \
           @defichain/jellyfish-wallet-mnemonic \
+          @defichain/playground-api-client \
           @defichain/whale-api-wallet
 
       - name: Create Pull Request

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,18 @@
 version: '3.7'
 
 services:
-  defi-blockchain:
-    image: defi/defichain:1.6.4
+  traefik:
+    image: traefik:v2.4
+    command:
+      - "--providers.docker=true"
+      - "--entrypoints.web.address=:3000"
     ports:
-      - "19554:19554"
+      - "3000:3000"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+  defi-blockchain:
+    image: defi/defichain:1.7.0
     command: >
       defid
       -printtoconsole
@@ -24,22 +32,31 @@ services:
       -clarkequayheight=3
       -dakotaheight=4
       -dakotacrescentheight=5
+      -eunosheight=6
 
-  defi-playground:
-    image: ghcr.io/defich/playground:0.0.1
-    ports:
-      - "12000:3000"
-    depends_on:
-      - defi-blockchain
-    environment:
-      PLAYGROUND_DEFID_URL: http://playground-rpcuser:playground-rpcpassword@defi-blockchain:19554
   defi-whale:
-    image: ghcr.io/defich/whale:0.1.3
-    ports:
-      - "13000:3000"
+    image: ghcr.io/defich/whale:0.2.1
     depends_on:
       - defi-blockchain
     environment:
       WHALE_DEFID_URL: http://playground-rpcuser:playground-rpcpassword@defi-blockchain:19554
-      WHALE_NETWORK: regtest
       WHALE_DATABASE_PROVIDER: level
+      WHALE_NETWORK: playground
+    labels:
+      - "traefik.http.routers.whale.priority=1"
+      - "traefik.http.routers.whale.rule=PathPrefix(`/{version:v[1-9]}/playground/`)"
+      - "traefik.http.routers.whale.entrypoints=web"
+      - "traefik.http.services.whale.loadbalancer.server.port=3000"
+
+  defi-playground:
+    build: ..
+    image: ghcr.io/defich/playground:0.0.2
+    depends_on:
+      - defi-blockchain
+    environment:
+      PLAYGROUND_DEFID_URL: http://playground-rpcuser:playground-rpcpassword@defi-blockchain:19554
+    labels:
+      - "traefik.http.routers.playground.priority=0"
+      - "traefik.http.routers.playground.rule=PathPrefix(`/{version:v[1-9]}/playground/rpc/`)"
+      - "traefik.http.routers.playground.entrypoints=web"
+      - "traefik.http.services.playground.loadbalancer.server.port=3000"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,11 @@
       "name": "@defichain/wallet",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-transaction-builder": "^0.6.0",
-        "@defichain/jellyfish-wallet": "^0.6.0",
-        "@defichain/jellyfish-wallet-mnemonic": "^0.6.0",
-        "@defichain/playground-api-client": "^0.0.1",
-        "@defichain/whale-api-wallet": "^0.1.3",
+        "@defichain/jellyfish-transaction-builder": ">=0.9.0",
+        "@defichain/jellyfish-wallet": ">=0.9.0",
+        "@defichain/jellyfish-wallet-mnemonic": ">=0.9.0",
+        "@defichain/playground-api-client": ">=0.0.2",
+        "@defichain/whale-api-wallet": ">=0.2.1",
         "@expo/vector-icons": "^12.0.0",
         "@expo/webpack-config": "~0.12.72",
         "@react-native-community/masked-view": "0.1.11",
@@ -1386,13 +1386,13 @@
       }
     },
     "node_modules/@defichain/jellyfish-address": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.6.0.tgz",
-      "integrity": "sha512-D0UWF9LomoLWLVP5gI7itANNTkxi2e+xS9JI7JmbiTWnmuSKDxVQcUz7laVCrGn0/LUdreitQ5AxTeWVewpPJw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.9.0.tgz",
+      "integrity": "sha512-Sanh1LK+YdHZdRhet2kiXQhPc1AEAgrKZoGMJ7yUOZYKSIDLpYZoZPCsgIfkAtk8NAt6uollt+NdlKYcfDfCiQ==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.6.0",
-        "@defichain/jellyfish-network": "^0.6.0",
-        "@defichain/jellyfish-transaction": "^0.6.0",
+        "@defichain/jellyfish-crypto": "^0.9.0",
+        "@defichain/jellyfish-network": "^0.9.0",
+        "@defichain/jellyfish-transaction": "^0.9.0",
         "bs58": "^4.0.1"
       }
     },
@@ -1405,9 +1405,9 @@
       }
     },
     "node_modules/@defichain/jellyfish-crypto": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.6.0.tgz",
-      "integrity": "sha512-d+jfcDQv4Kqec9rpd4UbTB3HCuwzrwEzXYxkKOq3M2vu/EyzoDDbFnNdt5nlkl2Xc2rLq3qND9ZroOuTJNMbTQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.9.0.tgz",
+      "integrity": "sha512-Pubvy7C/f0EcwVg+puxF9nTmdccPdJLETBcu7zVNayHQh72D5zVx+4C6ZL8sW9IeO670gd1ueuTYdr2mugGa6Q==",
       "dependencies": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -1426,53 +1426,62 @@
       }
     },
     "node_modules/@defichain/jellyfish-network": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.6.0.tgz",
-      "integrity": "sha512-h8s0MkHiisjn8owfZzDWzGge826Hxq4jZkiKOgOV9YT7JhkD+hVl1d7nNPE1wpLKfsNUnNyjK9GLjHDWTzUMIQ=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.9.0.tgz",
+      "integrity": "sha512-HEVwO5pmJc0S0JRNIOWAVIjhjX4JWleAXwIiHdv9jrSOae3ZqzCmBhadEb52DrgOELNX+jLzM7WL7IfVJc0nMw=="
     },
     "node_modules/@defichain/jellyfish-transaction": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.6.0.tgz",
-      "integrity": "sha512-MDRzuPKLeaz2Db/la2ynhFsA3nrfjyCiZm1Yjn/E54exMR2gKa3nFUv45qkSqsvDYANxDRBqcH30Z8/DlFAGhA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.9.0.tgz",
+      "integrity": "sha512-xnoXoli77WuUcCc+stCikEsnYH4PZMpneiFGLitFfcWl9rZb08rBVjW645t0cwDxXX8fa/yFlo2hiq2fs5RyEw==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.6.0",
+        "@defichain/jellyfish-crypto": "^0.9.0",
         "smart-buffer": "^4.1.0"
+      },
+      "peerDependencies": {
+        "bignumber.js": "^9.0.1"
       }
     },
     "node_modules/@defichain/jellyfish-transaction-builder": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.6.0.tgz",
-      "integrity": "sha512-5l/qGaIPggpuvnxcMxPSw1zaS930UxdjNiK+F7F/WZVujq/aTDao5we2DHP2cZfEPpAMvq4Cbxrg+buRl7uihQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.9.0.tgz",
+      "integrity": "sha512-wwpoK6wEframrXSwmDj6NTWjOFDyDWo6/D8fu5AHZmhHvbyROGdt/vbEJr513iIP/hLaUswA8TAQHJIB1jw8tQ==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.6.0",
-        "@defichain/jellyfish-transaction": "^0.6.0"
+        "@defichain/jellyfish-crypto": "^0.9.0",
+        "@defichain/jellyfish-transaction": "^0.9.0"
+      },
+      "peerDependencies": {
+        "bignumber.js": "^9.0.1"
       }
     },
     "node_modules/@defichain/jellyfish-wallet": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.6.0.tgz",
-      "integrity": "sha512-vO+t4i2QNaCLStAIXulArDSStcmK8WRoCef8ihd6qbU2hw50BX0tvpo5GnU/cP2Gv+uod+RLYaBsIgouGZyylw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.9.0.tgz",
+      "integrity": "sha512-JHfDNobW7QRyDxzU23ksBAnM1f/x0pfhAwjUTftjLyYMuPy1XiPs7ldbhHYpIdaRt3iXBXCUyenSEqfwING2ag==",
       "dependencies": {
-        "@defichain/jellyfish-address": "^0.6.0",
-        "@defichain/jellyfish-crypto": "^0.6.0",
-        "@defichain/jellyfish-transaction": "^0.6.0"
+        "@defichain/jellyfish-address": "^0.9.0",
+        "@defichain/jellyfish-crypto": "^0.9.0",
+        "@defichain/jellyfish-transaction": "^0.9.0"
+      },
+      "peerDependencies": {
+        "bignumber.js": "^9.0.1"
       }
     },
     "node_modules/@defichain/jellyfish-wallet-mnemonic": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet-mnemonic/-/jellyfish-wallet-mnemonic-0.6.0.tgz",
-      "integrity": "sha512-3jZ2boR734OV+Zx3r9Kd2QbRLUDxLwep7deisn/DavWRMx7f73jnnWUaqyf/zfDWJMDijVK44YHZQJ8QBXZx/A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet-mnemonic/-/jellyfish-wallet-mnemonic-0.9.0.tgz",
+      "integrity": "sha512-h0lQ+mainPFqSuR3MViZChl5XIHJ215EMy+2OjQkKiutnyfZkGIO1PDxI1V8PaPlJpDmEiRDcnHKjhQACbhOlg==",
       "dependencies": {
-        "@defichain/jellyfish-transaction": "^0.6.0",
-        "@defichain/jellyfish-wallet": "^0.6.0",
+        "@defichain/jellyfish-transaction": "^0.9.0",
+        "@defichain/jellyfish-wallet": "^0.9.0",
         "bip32": "^2.0.6",
         "bip39": "^3.0.3"
       }
     },
     "node_modules/@defichain/playground-api-client": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.0.1.tgz",
-      "integrity": "sha512-NQViyUsjOSeESIhXBtpdfGeeqynAGB7GG2MEjDMT3GicwXrsNgN2BUKuvMX2CuVSL3YYmCpa69J+VFQpN8tEdw==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.0.2.tgz",
+      "integrity": "sha512-MdWChyjDjF2zpsUtci31eG7DU2r4fhArhllX2wzUWqInjpmHUZ6F31ygfYEhC+HCJUMLCijkpazWg5Jlrzi5Uw==",
       "dependencies": {
         "@defichain/jellyfish-api-core": ">=0.0.0",
         "abort-controller": "^3.0.0",
@@ -1480,9 +1489,9 @@
       }
     },
     "node_modules/@defichain/whale-api-client": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.1.4.tgz",
-      "integrity": "sha512-kJ7D9rhbeC9AQGy2Y+opgn5KP6VJSpQp8CugtrIe13YqscrCZiZo4g9W9V1ibbGrMT6rZ1JknMxoE9dckHo6BA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.2.1.tgz",
+      "integrity": "sha512-I0YxHGjZEG4BhkF7pBEzFhsjvySzX+hQlv5hPus67VqEfoWHPK0/FkEWnwXxuw1c4dRde2c0rCnxmAKrqJbPRQ==",
       "dependencies": {
         "@defichain/jellyfish-api-core": ">=0.0.0",
         "abort-controller": "^3.0.0",
@@ -1490,70 +1499,13 @@
       }
     },
     "node_modules/@defichain/whale-api-wallet": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-wallet/-/whale-api-wallet-0.1.4.tgz",
-      "integrity": "sha512-RQb84fa9ooQTjhHaahMs9cymuYuIuwzstWyWIA4FAluN1cZ1AnyfCfGHQ/00BGyEtFi0Jlr6KZ8p7Lhn36MVfg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-wallet/-/whale-api-wallet-0.2.1.tgz",
+      "integrity": "sha512-ZNTR/NTW6ryOnnGJJpic1FH0k3Lk3X/XaKFSb6ex2PlZMTgAhYWzJ3zvDgLZ1P4lFi3u3bu3Crj55RpgiL6DKQ==",
       "dependencies": {
         "@defichain/jellyfish-transaction-builder": "next",
         "@defichain/jellyfish-wallet": "next",
-        "@defichain/whale-api-client": "^0.1.4"
-      }
-    },
-    "node_modules/@defichain/whale-api-wallet/node_modules/@defichain/jellyfish-address": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.7.1.tgz",
-      "integrity": "sha512-DnMPNCID8sppnNmsrTlAle8Ls9n3INqcSjDQzIunSuAhBHqgFkT9gMUeKa+icQ4G37AbS8UZ3SIgSsEEKaLMog==",
-      "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.7.1",
-        "@defichain/jellyfish-network": "^0.7.1",
-        "@defichain/jellyfish-transaction": "^0.7.1",
-        "bs58": "^4.0.1"
-      }
-    },
-    "node_modules/@defichain/whale-api-wallet/node_modules/@defichain/jellyfish-crypto": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.7.1.tgz",
-      "integrity": "sha512-ghQ3WSq2/nKDYoD7kDHoURO7U8yw9taUxv5Zg4KdZApsYFuZzFERhdVid/ExsdTWOjX8ySW1OEwe1oFS4zp7Zg==",
-      "dependencies": {
-        "bech32": "^2.0.0",
-        "bip66": "^1.1.5",
-        "bs58": "^4.0.1",
-        "create-hash": "^1.2.0",
-        "tiny-secp256k1": "^1.1.6",
-        "wif": "^2.0.6"
-      }
-    },
-    "node_modules/@defichain/whale-api-wallet/node_modules/@defichain/jellyfish-network": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.7.1.tgz",
-      "integrity": "sha512-iU2lb902/l/AKzcBPLsy3aSbb5c2g9kr3bO2XavmjluZGPhkvB42K4Mw94jM8G7fWV0mnQFOeOi/0Qg+xRMJBg=="
-    },
-    "node_modules/@defichain/whale-api-wallet/node_modules/@defichain/jellyfish-transaction": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.7.1.tgz",
-      "integrity": "sha512-qg8H+QPnkwlZ8rZIQ8qTmMkOxSOpKmMw1V2Wdw1I/xKZV/Q2L88yiRS+oDjTnHotYzvwP57/pum59AZRBlqKTg==",
-      "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.7.1",
-        "smart-buffer": "^4.1.0"
-      }
-    },
-    "node_modules/@defichain/whale-api-wallet/node_modules/@defichain/jellyfish-transaction-builder": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.7.1.tgz",
-      "integrity": "sha512-/W4pqs+MOIqBkdJohJde1Z2SAJ7G0gjUVUdGaviD1hbmqAUA94dUsMv0JQ38Je38TXn2bN/V/kzOw+nVITCFKw==",
-      "dependencies": {
-        "@defichain/jellyfish-crypto": "^0.7.1",
-        "@defichain/jellyfish-transaction": "^0.7.1"
-      }
-    },
-    "node_modules/@defichain/whale-api-wallet/node_modules/@defichain/jellyfish-wallet": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.7.1.tgz",
-      "integrity": "sha512-C+Ny20bN51j092skCPCMAQUvUPzd6ETcM8Stw8pyE2j2jOK+/9t8E0a7zNxFFrKZg7bTz2vBl7Yfhb9d1Nb5hg==",
-      "dependencies": {
-        "@defichain/jellyfish-address": "^0.7.1",
-        "@defichain/jellyfish-crypto": "^0.7.1",
-        "@defichain/jellyfish-transaction": "^0.7.1"
+        "@defichain/whale-api-client": "^0.2.1"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -32750,13 +32702,13 @@
       }
     },
     "@defichain/jellyfish-address": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.6.0.tgz",
-      "integrity": "sha512-D0UWF9LomoLWLVP5gI7itANNTkxi2e+xS9JI7JmbiTWnmuSKDxVQcUz7laVCrGn0/LUdreitQ5AxTeWVewpPJw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.9.0.tgz",
+      "integrity": "sha512-Sanh1LK+YdHZdRhet2kiXQhPc1AEAgrKZoGMJ7yUOZYKSIDLpYZoZPCsgIfkAtk8NAt6uollt+NdlKYcfDfCiQ==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.6.0",
-        "@defichain/jellyfish-network": "^0.6.0",
-        "@defichain/jellyfish-transaction": "^0.6.0",
+        "@defichain/jellyfish-crypto": "^0.9.0",
+        "@defichain/jellyfish-network": "^0.9.0",
+        "@defichain/jellyfish-transaction": "^0.9.0",
         "bs58": "^4.0.1"
       }
     },
@@ -32769,9 +32721,9 @@
       }
     },
     "@defichain/jellyfish-crypto": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.6.0.tgz",
-      "integrity": "sha512-d+jfcDQv4Kqec9rpd4UbTB3HCuwzrwEzXYxkKOq3M2vu/EyzoDDbFnNdt5nlkl2Xc2rLq3qND9ZroOuTJNMbTQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.9.0.tgz",
+      "integrity": "sha512-Pubvy7C/f0EcwVg+puxF9nTmdccPdJLETBcu7zVNayHQh72D5zVx+4C6ZL8sW9IeO670gd1ueuTYdr2mugGa6Q==",
       "requires": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -32790,53 +32742,53 @@
       }
     },
     "@defichain/jellyfish-network": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.6.0.tgz",
-      "integrity": "sha512-h8s0MkHiisjn8owfZzDWzGge826Hxq4jZkiKOgOV9YT7JhkD+hVl1d7nNPE1wpLKfsNUnNyjK9GLjHDWTzUMIQ=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.9.0.tgz",
+      "integrity": "sha512-HEVwO5pmJc0S0JRNIOWAVIjhjX4JWleAXwIiHdv9jrSOae3ZqzCmBhadEb52DrgOELNX+jLzM7WL7IfVJc0nMw=="
     },
     "@defichain/jellyfish-transaction": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.6.0.tgz",
-      "integrity": "sha512-MDRzuPKLeaz2Db/la2ynhFsA3nrfjyCiZm1Yjn/E54exMR2gKa3nFUv45qkSqsvDYANxDRBqcH30Z8/DlFAGhA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.9.0.tgz",
+      "integrity": "sha512-xnoXoli77WuUcCc+stCikEsnYH4PZMpneiFGLitFfcWl9rZb08rBVjW645t0cwDxXX8fa/yFlo2hiq2fs5RyEw==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.6.0",
+        "@defichain/jellyfish-crypto": "^0.9.0",
         "smart-buffer": "^4.1.0"
       }
     },
     "@defichain/jellyfish-transaction-builder": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.6.0.tgz",
-      "integrity": "sha512-5l/qGaIPggpuvnxcMxPSw1zaS930UxdjNiK+F7F/WZVujq/aTDao5we2DHP2cZfEPpAMvq4Cbxrg+buRl7uihQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.9.0.tgz",
+      "integrity": "sha512-wwpoK6wEframrXSwmDj6NTWjOFDyDWo6/D8fu5AHZmhHvbyROGdt/vbEJr513iIP/hLaUswA8TAQHJIB1jw8tQ==",
       "requires": {
-        "@defichain/jellyfish-crypto": "^0.6.0",
-        "@defichain/jellyfish-transaction": "^0.6.0"
+        "@defichain/jellyfish-crypto": "^0.9.0",
+        "@defichain/jellyfish-transaction": "^0.9.0"
       }
     },
     "@defichain/jellyfish-wallet": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.6.0.tgz",
-      "integrity": "sha512-vO+t4i2QNaCLStAIXulArDSStcmK8WRoCef8ihd6qbU2hw50BX0tvpo5GnU/cP2Gv+uod+RLYaBsIgouGZyylw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.9.0.tgz",
+      "integrity": "sha512-JHfDNobW7QRyDxzU23ksBAnM1f/x0pfhAwjUTftjLyYMuPy1XiPs7ldbhHYpIdaRt3iXBXCUyenSEqfwING2ag==",
       "requires": {
-        "@defichain/jellyfish-address": "^0.6.0",
-        "@defichain/jellyfish-crypto": "^0.6.0",
-        "@defichain/jellyfish-transaction": "^0.6.0"
+        "@defichain/jellyfish-address": "^0.9.0",
+        "@defichain/jellyfish-crypto": "^0.9.0",
+        "@defichain/jellyfish-transaction": "^0.9.0"
       }
     },
     "@defichain/jellyfish-wallet-mnemonic": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet-mnemonic/-/jellyfish-wallet-mnemonic-0.6.0.tgz",
-      "integrity": "sha512-3jZ2boR734OV+Zx3r9Kd2QbRLUDxLwep7deisn/DavWRMx7f73jnnWUaqyf/zfDWJMDijVK44YHZQJ8QBXZx/A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet-mnemonic/-/jellyfish-wallet-mnemonic-0.9.0.tgz",
+      "integrity": "sha512-h0lQ+mainPFqSuR3MViZChl5XIHJ215EMy+2OjQkKiutnyfZkGIO1PDxI1V8PaPlJpDmEiRDcnHKjhQACbhOlg==",
       "requires": {
-        "@defichain/jellyfish-transaction": "^0.6.0",
-        "@defichain/jellyfish-wallet": "^0.6.0",
+        "@defichain/jellyfish-transaction": "^0.9.0",
+        "@defichain/jellyfish-wallet": "^0.9.0",
         "bip32": "^2.0.6",
         "bip39": "^3.0.3"
       }
     },
     "@defichain/playground-api-client": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.0.1.tgz",
-      "integrity": "sha512-NQViyUsjOSeESIhXBtpdfGeeqynAGB7GG2MEjDMT3GicwXrsNgN2BUKuvMX2CuVSL3YYmCpa69J+VFQpN8tEdw==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.0.2.tgz",
+      "integrity": "sha512-MdWChyjDjF2zpsUtci31eG7DU2r4fhArhllX2wzUWqInjpmHUZ6F31ygfYEhC+HCJUMLCijkpazWg5Jlrzi5Uw==",
       "requires": {
         "@defichain/jellyfish-api-core": ">=0.0.0",
         "abort-controller": "^3.0.0",
@@ -32844,9 +32796,9 @@
       }
     },
     "@defichain/whale-api-client": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.1.4.tgz",
-      "integrity": "sha512-kJ7D9rhbeC9AQGy2Y+opgn5KP6VJSpQp8CugtrIe13YqscrCZiZo4g9W9V1ibbGrMT6rZ1JknMxoE9dckHo6BA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.2.1.tgz",
+      "integrity": "sha512-I0YxHGjZEG4BhkF7pBEzFhsjvySzX+hQlv5hPus67VqEfoWHPK0/FkEWnwXxuw1c4dRde2c0rCnxmAKrqJbPRQ==",
       "requires": {
         "@defichain/jellyfish-api-core": ">=0.0.0",
         "abort-controller": "^3.0.0",
@@ -32854,72 +32806,13 @@
       }
     },
     "@defichain/whale-api-wallet": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-wallet/-/whale-api-wallet-0.1.4.tgz",
-      "integrity": "sha512-RQb84fa9ooQTjhHaahMs9cymuYuIuwzstWyWIA4FAluN1cZ1AnyfCfGHQ/00BGyEtFi0Jlr6KZ8p7Lhn36MVfg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-wallet/-/whale-api-wallet-0.2.1.tgz",
+      "integrity": "sha512-ZNTR/NTW6ryOnnGJJpic1FH0k3Lk3X/XaKFSb6ex2PlZMTgAhYWzJ3zvDgLZ1P4lFi3u3bu3Crj55RpgiL6DKQ==",
       "requires": {
         "@defichain/jellyfish-transaction-builder": "next",
         "@defichain/jellyfish-wallet": "next",
-        "@defichain/whale-api-client": "^0.1.4"
-      },
-      "dependencies": {
-        "@defichain/jellyfish-address": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.7.1.tgz",
-          "integrity": "sha512-DnMPNCID8sppnNmsrTlAle8Ls9n3INqcSjDQzIunSuAhBHqgFkT9gMUeKa+icQ4G37AbS8UZ3SIgSsEEKaLMog==",
-          "requires": {
-            "@defichain/jellyfish-crypto": "^0.7.1",
-            "@defichain/jellyfish-network": "^0.7.1",
-            "@defichain/jellyfish-transaction": "^0.7.1",
-            "bs58": "^4.0.1"
-          }
-        },
-        "@defichain/jellyfish-crypto": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.7.1.tgz",
-          "integrity": "sha512-ghQ3WSq2/nKDYoD7kDHoURO7U8yw9taUxv5Zg4KdZApsYFuZzFERhdVid/ExsdTWOjX8ySW1OEwe1oFS4zp7Zg==",
-          "requires": {
-            "bech32": "^2.0.0",
-            "bip66": "^1.1.5",
-            "bs58": "^4.0.1",
-            "create-hash": "^1.2.0",
-            "tiny-secp256k1": "^1.1.6",
-            "wif": "^2.0.6"
-          }
-        },
-        "@defichain/jellyfish-network": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.7.1.tgz",
-          "integrity": "sha512-iU2lb902/l/AKzcBPLsy3aSbb5c2g9kr3bO2XavmjluZGPhkvB42K4Mw94jM8G7fWV0mnQFOeOi/0Qg+xRMJBg=="
-        },
-        "@defichain/jellyfish-transaction": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.7.1.tgz",
-          "integrity": "sha512-qg8H+QPnkwlZ8rZIQ8qTmMkOxSOpKmMw1V2Wdw1I/xKZV/Q2L88yiRS+oDjTnHotYzvwP57/pum59AZRBlqKTg==",
-          "requires": {
-            "@defichain/jellyfish-crypto": "^0.7.1",
-            "smart-buffer": "^4.1.0"
-          }
-        },
-        "@defichain/jellyfish-transaction-builder": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction-builder/-/jellyfish-transaction-builder-0.7.1.tgz",
-          "integrity": "sha512-/W4pqs+MOIqBkdJohJde1Z2SAJ7G0gjUVUdGaviD1hbmqAUA94dUsMv0JQ38Je38TXn2bN/V/kzOw+nVITCFKw==",
-          "requires": {
-            "@defichain/jellyfish-crypto": "^0.7.1",
-            "@defichain/jellyfish-transaction": "^0.7.1"
-          }
-        },
-        "@defichain/jellyfish-wallet": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-wallet/-/jellyfish-wallet-0.7.1.tgz",
-          "integrity": "sha512-C+Ny20bN51j092skCPCMAQUvUPzd6ETcM8Stw8pyE2j2jOK+/9t8E0a7zNxFFrKZg7bTz2vBl7Yfhb9d1Nb5hg==",
-          "requires": {
-            "@defichain/jellyfish-address": "^0.7.1",
-            "@defichain/jellyfish-crypto": "^0.7.1",
-            "@defichain/jellyfish-transaction": "^0.7.1"
-          }
-        }
+        "@defichain/whale-api-client": "^0.2.1"
       }
     },
     "@egjs/hammerjs": {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@defichain/jellyfish-transaction-builder": "^0.6.0",
-    "@defichain/jellyfish-wallet": "^0.6.0",
-    "@defichain/jellyfish-wallet-mnemonic": "^0.6.0",
-    "@defichain/playground-api-client": "^0.0.1",
-    "@defichain/whale-api-wallet": "^0.1.3",
+    "@defichain/jellyfish-transaction-builder": ">=0.9.0",
+    "@defichain/jellyfish-wallet": ">=0.9.0",
+    "@defichain/jellyfish-wallet-mnemonic": ">=0.9.0",
+    "@defichain/playground-api-client": ">=0.0.2",
+    "@defichain/whale-api-wallet": ">=0.2.1",
     "@expo/vector-icons": "^12.0.0",
     "@expo/webpack-config": "~0.12.72",
     "@react-native-community/masked-view": "0.1.11",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind dependencies

#### What this PR does / why we need it:

1. bump defichain-dependencies to always stay on bleeding edge version with`>=` resolution
2. also updated whale & playground to use the latest docker version