### PR TITLE
Translations fix to prevent "guessing" results

### DIFF
--- a/translations/index.ts
+++ b/translations/index.ts
@@ -53,5 +53,9 @@ export function translate (path: string, text: string): string {
     initI18n()
   }
   const translation = i18n.translate(`${path}.${text}`)
-  return translation != null && translation !== '' ? translation : text
+  if (translation !== null && translation !== undefined && translation !== '') {
+    return translation
+  } else {
+    return text
+  }
 }

--- a/translations/index.ts
+++ b/translations/index.ts
@@ -41,7 +41,7 @@ export function initI18n (): void {
   }
   i18n.locale = Localization.locale
   i18n.fallbacks = true
-  i18n.missingBehaviour = 'guess'
+  i18n.missingTranslation = () => null
 }
 
 /**
@@ -52,5 +52,6 @@ export function translate (path: string, text: string): string {
   if (!init) {
     initI18n()
   }
-  return i18n.translate(`${path}.${text}`)
+  const translation = i18n.translate(`${path}.${text}`)
+  return translation != null && translation !== '' ? translation : text
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
Currently, `i18njs` behavior is to "guess" the missing translations. It is causing some issues with texts that contains punctuation marks. Also, it replaces camel case text with spaces which is an issue with some proper nouns (ex. WeChat -> We Chat). Reference - https://github.com/fnando/i18n-js#translation-missing-behaviour-control

Current behavior is to use the "text" as fallback if translation is missing.
#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
