### PR TITLE
Added temporary remote playground

### DIFF
--- a/hooks/api/useNetwork.ts
+++ b/hooks/api/useNetwork.ts
@@ -1,9 +1,9 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
-import { network, NetworkName, PlaygroundApiState } from '../../store/network'
 import { PlaygroundApiClient } from '@defichain/playground-api-client'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { Dispatch } from 'redux'
-import { useEffect, useState } from 'react'
+import { network, NetworkName, PlaygroundApiState } from '../../store/network'
 
 export function useNetwork (): boolean {
   const dispatch = useDispatch()
@@ -63,6 +63,6 @@ async function loadPlayground (): Promise<PlaygroundApiState> {
   }
 
   // Always fallback to playground.ocean even if it's not available
-  const url = 'https://playground.ocean.defichain.com'
-  return { url, environment: 'ocean' }
+  const url = 'http://52.221.214.183'
+  return { url, environment: 'remote' }
 }

--- a/store/network.ts
+++ b/store/network.ts
@@ -1,10 +1,10 @@
-import { createSlice, PayloadAction, createSelector } from '@reduxjs/toolkit'
+import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 export type NetworkName = 'mainnet' | 'testnet' | 'regtest' | 'playground'
 
 export interface PlaygroundApiState {
   url: string
-  environment: 'localhost' | 'ocean'
+  environment: 'localhost' | 'remote'
 }
 
 export interface WhaleApiState {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

This allows users to use playground without setting up their local version.