### PR TITLE
removed deprecated package `react-native-testing-library`

### DIFF
--- a/components/icons/tokens/_index.test.tsx
+++ b/components/icons/tokens/_index.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { getTokenIcon } from "./_index";
-import { render } from "react-native-testing-library";
+import { render } from "@testing-library/react-native";
 
 it('getTokenIcon("DFI") should get <IconDFI /> snapshot', () => {
   const Icon = getTokenIcon('DFI')

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       },
       "devDependencies": {
         "@babel/core": "~7.9.0",
+        "@testing-library/react-native": "^7.2.0",
         "@types/find-in-files": "^0.5.1",
         "@types/i18n-js": "^3.8.0",
         "@types/jest": "^26.0.22",
@@ -67,7 +68,6 @@
         "husky": "^6.0.0",
         "jest-expo": "^41.0.0",
         "lint-staged": "^11.0.0",
-        "react-native-testing-library": "^6.0.0",
         "react-test-renderer": "~16.13.1",
         "ts-node": "^10.0.0",
         "ts-standard": "^10.0.0",
@@ -6070,6 +6070,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-7.2.0.tgz",
+      "integrity": "sha512-rDKzJjAAeGgyoJT0gFQiMsIL09chdWcwZyYx6WZHMgm2c5NDqY52hUuyTkzhqddMYWmSRklFphSg7B2HX+246Q==",
+      "dev": true,
+      "dependencies": {
+        "pretty-format": "^26.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -26583,20 +26597,6 @@
         "react-native": ">=0.50.0"
       }
     },
-    "node_modules/react-native-testing-library": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-testing-library/-/react-native-testing-library-6.0.0.tgz",
-      "integrity": "sha512-BobXLtlef+gklN6cl6oC20/rnW9lWGj7Yxzzn+fTb+9go0LnGGgJ8DNaJtuW5oS7pOkm1Wq+u+cypALyf32FjA==",
-      "deprecated": "🚨 react-native-testing-library has moved to @testing-library/react-native. Please uninstall react-native-testing-library and install @testing-library/react-native instead, or use an older version of react-native-testing-library. Learn more about this change here: https://github.com/callstack/react-native-testing-library/issues/442. Thanks! :)",
-      "dev": true,
-      "dependencies": {
-        "pretty-format": "^26.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-test-renderer": ">=16.0.0"
-      }
-    },
     "node_modules/react-native-web": {
       "version": "0.13.18",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.13.18.tgz",
@@ -38956,6 +38956,15 @@
       "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
       "requires": {
         "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@testing-library/react-native": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-7.2.0.tgz",
+      "integrity": "sha512-rDKzJjAAeGgyoJT0gFQiMsIL09chdWcwZyYx6WZHMgm2c5NDqY52hUuyTkzhqddMYWmSRklFphSg7B2HX+246Q==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^26.0.1"
       }
     },
     "@tootallnate/once": {
@@ -52037,6 +52046,7 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.59.0.tgz",
       "integrity": "sha512-1O3wrnMq4NcPQ1asEcl9lRDn/t+F1Oef6S9WaYVIKEhg9m/EQRGVrrTVP+R6B5Eeaj3+zNKbzM8Dx/NWy1hUbQ==",
       "requires": {
+        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.59.0",
         "metro-react-native-babel-preset": "0.59.0",
@@ -55408,15 +55418,6 @@
       "requires": {
         "css-select": "^2.1.0",
         "css-tree": "^1.0.0-alpha.39"
-      }
-    },
-    "react-native-testing-library": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-testing-library/-/react-native-testing-library-6.0.0.tgz",
-      "integrity": "sha512-BobXLtlef+gklN6cl6oC20/rnW9lWGj7Yxzzn+fTb+9go0LnGGgJ8DNaJtuW5oS7pOkm1Wq+u+cypALyf32FjA==",
-      "dev": true,
-      "requires": {
-        "pretty-format": "^26.0.1"
       }
     },
     "react-native-web": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",
+    "@testing-library/react-native": "^7.2.0",
     "@types/find-in-files": "^0.5.1",
     "@types/i18n-js": "^3.8.0",
     "@types/jest": "^26.0.22",
@@ -76,7 +77,6 @@
     "husky": "^6.0.0",
     "jest-expo": "^41.0.0",
     "lint-staged": "^11.0.0",
-    "react-native-testing-library": "^6.0.0",
     "react-test-renderer": "~16.13.1",
     "ts-node": "^10.0.0",
     "ts-standard": "^10.0.0",

--- a/screens/LoadingNavigator/LoadingScreen.test.tsx
+++ b/screens/LoadingNavigator/LoadingScreen.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render } from 'react-native-testing-library'
+import { render } from '@testing-library/react-native'
 
 import LoadingScreen from './LoadingScreen'
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:
Removed deprecated `react-native-testing-library` and replaced with `@testing-library/react-native`. See https://www.npmjs.com/package/react-native-testing-library
#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
