### PR TITLE
updated all icons to use MaterialIcons set

### DIFF
--- a/constants/Theme.ts
+++ b/constants/Theme.ts
@@ -1,5 +1,7 @@
+import { MaterialIcons } from '@expo/vector-icons'
 import { DefaultTheme } from '@react-navigation/native'
 import { Theme } from '@react-navigation/native/lib/typescript/src/types'
+import * as React from 'react'
 import { StyleSheet } from 'react-native'
 
 export const PrimaryColor = '#ff00af'
@@ -20,3 +22,6 @@ export const DeFiChainTheme: Theme = {
     primary: PrimaryColor
   }
 }
+
+export const VectorIcon = MaterialIcons
+export type VectorIconName = React.ComponentProps<typeof MaterialIcons>['name']

--- a/hooks/design/useCachedResources.ts
+++ b/hooks/design/useCachedResources.ts
@@ -1,4 +1,4 @@
-import { Ionicons } from '@expo/vector-icons'
+import { MaterialCommunityIcons } from '@expo/vector-icons'
 import * as Font from 'expo-font'
 import * as React from 'react'
 
@@ -20,7 +20,7 @@ export function useCachedResources (): boolean {
 async function loadResourcesAndDataAsync (): Promise<void> {
   try {
     await Font.loadAsync({
-      ...Ionicons.font,
+      ...MaterialCommunityIcons.font,
       'space-mono': require('../../assets/fonts/SpaceMono-Regular.ttf')
     })
   } catch (e) {

--- a/screens/AppNavigator/BottomTabNavigator.tsx
+++ b/screens/AppNavigator/BottomTabNavigator.tsx
@@ -1,7 +1,7 @@
-import { Ionicons } from '@expo/vector-icons'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import { PathConfigMap } from '@react-navigation/core'
 import * as React from 'react'
+import { VectorIcon, VectorIconName } from '../../constants/Theme'
 
 import { BalancesNavigator } from './screens/BalancesScreen/BalancesNavigator'
 import { LiquidityNavigator } from './screens/LiquidityScreen/LiquidityScreen'
@@ -22,8 +22,8 @@ const BottomTab = createBottomTabNavigator<BottomTabParamList>()
 /**
  * @see https://icons.expo.fyi/ to filter => Ionicons
  */
-function TabBarIcon (props: { name: React.ComponentProps<typeof Ionicons>['name'], color: string }): JSX.Element {
-  return <Ionicons size={24} {...props} />
+function TabBarIcon (props: { name: VectorIconName, color: string }): JSX.Element {
+  return <VectorIcon size={24} {...props} />
 }
 
 export function BottomTabNavigator (): JSX.Element {
@@ -37,7 +37,7 @@ export function BottomTabNavigator (): JSX.Element {
         component={BalancesNavigator}
         options={{
           tabBarTestID: 'bottom_tab_balances',
-          tabBarIcon: ({ color }) => <TabBarIcon name='wallet' color={color} />
+          tabBarIcon: ({ color }) => <TabBarIcon name='account-balance-wallet' color={color} />
         }}
       />
       <BottomTab.Screen
@@ -53,7 +53,7 @@ export function BottomTabNavigator (): JSX.Element {
         component={TransactionsNavigator}
         options={{
           tabBarTestID: 'bottom_tab_transactions',
-          tabBarIcon: ({ color }) => <TabBarIcon name='time' color={color} />
+          tabBarIcon: ({ color }) => <TabBarIcon name='access-time' color={color} />
         }}
       />
       <BottomTab.Screen

--- a/screens/AppNavigator/screens/SettingsScreen/SettingsNavigator.tsx
+++ b/screens/AppNavigator/screens/SettingsScreen/SettingsNavigator.tsx
@@ -1,13 +1,12 @@
 import { useNavigation } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
-import { TouchableOpacity } from 'react-native'
 import * as React from 'react'
+import { TouchableOpacity } from 'react-native'
 import tailwind from 'tailwind-rn'
-import { PrimaryColor } from '../../../../constants/Theme'
+import { PrimaryColor, VectorIcon } from '../../../../constants/Theme'
 import { translate } from '../../../../translations'
-import { SettingsScreen } from './SettingsScreen'
 import { HelpScreen } from '../HelpScreen/HelpScreen'
-import { Ionicons } from '@expo/vector-icons'
+import { SettingsScreen } from './SettingsScreen'
 
 export interface SettingsParamList {
   SettingsScreen: undefined
@@ -40,7 +39,7 @@ function HelpButton (): JSX.Element {
   const navigation = useNavigation()
   return (
     <TouchableOpacity testID='settings_help_button' style={tailwind('m-2')} onPress={() => navigation.navigate('help')}>
-      <Ionicons name='help-circle-outline' size={28} color={PrimaryColor} />
+      <VectorIcon name='help-outline' size={24} color={PrimaryColor} />
     </TouchableOpacity>
   )
 }

--- a/screens/AppNavigator/screens/SettingsScreen/SettingsScreen.tsx
+++ b/screens/AppNavigator/screens/SettingsScreen/SettingsScreen.tsx
@@ -1,11 +1,10 @@
-import { Ionicons } from '@expo/vector-icons'
 import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
 import { SectionList, TouchableOpacity } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import tailwind from 'tailwind-rn'
 import { Text, View } from '../../../../components'
-import { PrimaryColor, PrimaryColorStyle } from '../../../../constants/Theme'
+import { PrimaryColor, PrimaryColorStyle, VectorIcon } from '../../../../constants/Theme'
 import { useWalletAPI } from '../../../../hooks/wallet/WalletAPI'
 import { RootState } from '../../../../store'
 import { NetworkName } from '../../../../store/network'
@@ -87,7 +86,7 @@ function RowNetworkItem (network?: NetworkName, onPress?: () => void): JSX.Eleme
       <Text style={tailwind('py-4')}>
         {getNetworkName()}
       </Text>
-      <Ionicons size={20} name='checkmark-sharp' color={PrimaryColor} />
+      <VectorIcon size={24} name='check' color={PrimaryColor} />
     </TouchableOpacity>
   )
 }

--- a/screens/WalletNavigator/screens/WalletMnemonicCreate.tsx
+++ b/screens/WalletNavigator/screens/WalletMnemonicCreate.tsx
@@ -1,12 +1,11 @@
 import { generateMnemonic } from '@defichain/jellyfish-wallet-mnemonic'
-import { Ionicons } from '@expo/vector-icons'
 import { StackScreenProps } from '@react-navigation/stack'
 import * as Random from 'expo-random'
 import * as React from 'react'
 import { ScrollView, TouchableOpacity } from 'react-native'
 import tailwind from 'tailwind-rn'
 import { Text, View } from '../../../components'
-import { PrimaryColor, PrimaryColorStyle } from '../../../constants/Theme'
+import { PrimaryColor, PrimaryColorStyle, VectorIcon } from '../../../constants/Theme'
 import { WalletParamList } from '../WalletNavigator'
 
 type Props = StackScreenProps<WalletParamList, 'WalletMnemonicCreate'>
@@ -78,7 +77,7 @@ function MnemonicWordRow (props: { index: number, word: string }): JSX.Element {
 function MnemonicTipRow (props: { positive: boolean, text: string }): JSX.Element {
   return (
     <View style={tailwind('flex-row mt-3')}>
-      <Ionicons size={24} name={props.positive ? 'checkmark-circle' : 'alert-circle'} color={PrimaryColor} />
+      <VectorIcon size={24} name={props.positive ? 'check' : 'error'} color={PrimaryColor} />
       <Text style={tailwind('flex-1 ml-2 text-sm')}>
         {props.text}
       </Text>

--- a/screens/WalletNavigator/screens/WalletOnboarding.tsx
+++ b/screens/WalletNavigator/screens/WalletOnboarding.tsx
@@ -1,11 +1,10 @@
-import { Ionicons } from '@expo/vector-icons'
 import { useNavigation } from '@react-navigation/native'
 import * as React from 'react'
 import { ScrollView, TouchableOpacity } from 'react-native'
 import { useDispatch } from 'react-redux'
 import tailwind from 'tailwind-rn'
 import { Text, View } from '../../../components'
-import { PrimaryColor } from '../../../constants/Theme'
+import { PrimaryColor, VectorIcon, VectorIconName } from '../../../constants/Theme'
 import { useWalletAPI } from '../../../hooks/wallet/WalletAPI'
 import { translate } from '../../../translations'
 
@@ -24,7 +23,7 @@ export function WalletOnboarding (): JSX.Element {
       <View style={tailwind('flex items-center')}>
         <TouchableOpacity delayLongPress={5000} onLongPress={onDebugPress}>
           <View style={tailwind('flex bg-white justify-center items-center rounded-full h-16 w-16')}>
-            <Ionicons size={24} name='wallet' color='#999' />
+            <VectorIcon size={26} name='account-balance-wallet' color='#999' />
           </View>
         </TouchableOpacity>
 
@@ -36,32 +35,32 @@ export function WalletOnboarding (): JSX.Element {
       <View style={tailwind('mt-8')}>
         <WalletOptionRow
           onPress={() => navigator.navigate('WalletMnemonicCreate')}
-          text='Create new mnemonic wallet' icon='time'
+          text='Create new mnemonic wallet' icon='account-balance-wallet'
         />
         <View style={tailwind('h-px bg-gray-100')} />
         <WalletOptionRow
           onPress={() => navigator.navigate('WalletMnemonicRestore')}
-          text='Restore mnemonic wallet' icon='document-text'
+          text='Restore mnemonic wallet' icon='restore-page'
         />
       </View>
     </ScrollView>
   )
 }
 
-function WalletOptionRow (props: { text: string, icon: string, onPress: () => void }): JSX.Element {
+function WalletOptionRow (props: { text: string, icon: VectorIconName, onPress: () => void }): JSX.Element {
   return (
     <TouchableOpacity
       onPress={props.onPress}
       style={tailwind('flex-row items-center justify-between px-4 bg-white')}
     >
       <View style={tailwind('flex-row items-center')}>
-        <Ionicons name={props.icon as any} size={20} color={PrimaryColor} />
+        <VectorIcon name={props.icon} size={24} color={PrimaryColor} />
         <Text style={tailwind('font-medium ml-3 py-4')}>
           {props.text}
         </Text>
       </View>
       <View>
-        <Ionicons name='chevron-forward' size={24} />
+        <VectorIcon name='chevron-right' size={24} />
       </View>
     </TouchableOpacity>
   )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Updated existing icon set to use MaterialIcons set.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #164 

#### Additional comments?:

- I am not a big fan of using Material on non-android devices, we should use a platform-agnostic icon set. We should change the icon set in the future.
- Did not use the MaterialCommunity set as it's not a superset of Material and the icons' name and style are not consistent with the original material guidelines.