### PR TITLE
clean up and reduced styles for Balances

### DIFF
--- a/cypress/integration/functional/balances.spec.ts
+++ b/cypress/integration/functional/balances.spec.ts
@@ -23,7 +23,7 @@ context('wallet/balances', () => {
   })
 
   it('should display navigation buttons and be able to redirect', function () {
-    cy.getByTestID('button_receive').should('exist').click()
+    cy.getByTestID('button_RECEIVE').should('exist').click()
     cy.location().should((loc) => {
       expect(loc.href).contains('Receive')
     })

--- a/cypress/integration/functional/balances.spec.ts
+++ b/cypress/integration/functional/balances.spec.ts
@@ -16,7 +16,6 @@ context('wallet/balances', () => {
 
   it('should display DFI and BTC tokens with correct amounts', function () {
     cy.getByTestID('balances_list').should('exist')
-    cy.getByTestID('balances_title').should('exist').contains('Portfolio')
     cy.getByTestID('balances_row_0').should('exist')
     cy.getByTestID('balances_row_1').should('exist')
     cy.getByTestID('balances_row_0_amount').contains(10)
@@ -26,7 +25,7 @@ context('wallet/balances', () => {
   it('should display navigation buttons and be able to redirect', function () {
     cy.getByTestID('button_receive').should('exist').click()
     cy.location().should((loc) => {
-      expect(loc.href).contains('receive')
+      expect(loc.href).contains('Receive')
     })
   })
 })

--- a/screens/AppNavigator/screens/BalancesScreen/BalancesNavigator.tsx
+++ b/screens/AppNavigator/screens/BalancesScreen/BalancesNavigator.tsx
@@ -1,30 +1,31 @@
+import { createStackNavigator } from '@react-navigation/stack'
 import * as React from 'react'
 import { translate } from '../../../../translations'
-import { createStackNavigator } from '@react-navigation/stack'
 import { BalancesScreen } from './BalancesScreen'
 import { ReceiveScreen } from './ReceiveScreen/ReceiveScreen'
 
-export interface BalancesParamList {
+export interface BalanceParamList {
   BalancesScreen: undefined
+  ReceiveScreen: undefined
 
   [key: string]: undefined | object
 }
 
-const Balances = createStackNavigator<BalancesParamList>()
+const BalanceStack = createStackNavigator<BalanceParamList>()
 
 export function BalancesNavigator (): JSX.Element {
   return (
-    <Balances.Navigator>
-      <Balances.Screen
-        name='balances'
+    <BalanceStack.Navigator>
+      <BalanceStack.Screen
+        name='Balances'
         component={BalancesScreen}
-        options={{ headerTitle: translate('screens/BalancesScreen', 'Balances') }}
+        options={{ headerTitle: translate('screens/BalancesScreen', 'Wallet Balances') }}
       />
-      <Balances.Screen
-        name='receive'
+      <BalanceStack.Screen
+        name='Receive'
         component={ReceiveScreen}
         options={{ headerTitle: translate('screens/ReceiveScreen', 'Receive') }}
       />
-    </Balances.Navigator>
+    </BalanceStack.Navigator>
   )
 }

--- a/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.test.tsx
+++ b/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.test.tsx
@@ -99,7 +99,7 @@ describe('balances page', () => {
       </Provider>
     );
     const rendered = render(component)
-    const receiveButton = await rendered.findByTestId('button_receive')
+    const receiveButton = await rendered.findByTestId('button_RECEIVE')
     fireEvent.press(receiveButton)
     expect(spy).toHaveBeenCalled()
   })

--- a/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.tsx
+++ b/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.tsx
@@ -44,11 +44,11 @@ export function BalancesScreen ({ navigation }: Props): JSX.Element {
       ListHeaderComponent={
         <View style={tailwind('flex-row justify-end px-4 py-3 bg-white border-b border-gray-200')}>
           <BalanceActionButton
-            icon='arrow-downward' title='RECEIVE'
+            icon='arrow-downward' title='receive'
             onPress={() => navigation.navigate('Receive')}
           />
           <BalanceActionButton
-            icon='arrow-upward' title='SEND'
+            icon='arrow-upward' title='send'
             onPress={() => navigation.navigate('Send')}
           />
         </View>
@@ -61,7 +61,7 @@ function BalanceItemRow ({ token }: { token: AddressToken }): JSX.Element {
   const Icon = getTokenIcon(token.symbol)
 
   return (
-    <View testID='balance_item_row' style={tailwind('bg-white p-4 flex-row justify-between items-center')}>
+    <View testID={`balances_row_${token.id}`} style={tailwind('bg-white p-4 flex-row justify-between items-center')}>
       <View style={tailwind('flex-row items-center')}>
         <Icon />
         <View style={tailwind('mx-3')}>
@@ -72,7 +72,7 @@ function BalanceItemRow ({ token }: { token: AddressToken }): JSX.Element {
 
       <NumberFormat
         value={token.amount} decimalScale={3} thousandSeparator displayType='text'
-        renderText={(value) => <Text>{value}</Text>}
+        renderText={(value) => <Text testID={`balances_row_${token.id}_amount`}>{value}</Text>}
       />
     </View>
   )
@@ -85,7 +85,7 @@ function BalanceActionButton (props: {
 }): JSX.Element {
   return (
     <TouchableOpacity
-      style={[tailwind('px-2 py-1.5 ml-3 flex-row items-center border border-gray-300 rounded')]}
+      testID={`button_${props.title}`} style={[tailwind('px-2 py-1.5 ml-3 flex-row items-center border border-gray-300 rounded uppercase')]}
       onPress={props.onPress}
     >
       <MaterialIcons name={props.icon} size={20} color={PrimaryColor} />

--- a/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.tsx
+++ b/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.tsx
@@ -44,11 +44,11 @@ export function BalancesScreen ({ navigation }: Props): JSX.Element {
       ListHeaderComponent={
         <View style={tailwind('flex-row justify-end px-4 py-3 bg-white border-b border-gray-200')}>
           <BalanceActionButton
-            icon='arrow-downward' title='receive'
+            icon='arrow-downward' title='RECEIVE'
             onPress={() => navigation.navigate('Receive')}
           />
           <BalanceActionButton
-            icon='arrow-upward' title='send'
+            icon='arrow-upward' title='SEND'
             onPress={() => navigation.navigate('Send')}
           />
         </View>
@@ -89,7 +89,7 @@ function BalanceActionButton (props: {
       onPress={props.onPress}
     >
       <MaterialIcons name={props.icon} size={20} color={PrimaryColor} />
-      <Text style={[tailwind('mx-1 uppercase'), PrimaryColorStyle.text]}>
+      <Text style={[tailwind('mx-1'), PrimaryColorStyle.text]}>
         {translate('screens/BalancesScreen', props.title)}
       </Text>
     </TouchableOpacity>

--- a/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.tsx
+++ b/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.tsx
@@ -85,11 +85,11 @@ function BalanceActionButton (props: {
 }): JSX.Element {
   return (
     <TouchableOpacity
-      testID={`button_${props.title}`} style={[tailwind('px-2 py-1.5 ml-3 flex-row items-center border border-gray-300 rounded uppercase')]}
+      testID={`button_${props.title}`} style={[tailwind('px-2 py-1.5 ml-3 flex-row items-center border border-gray-300 rounded')]}
       onPress={props.onPress}
     >
       <MaterialIcons name={props.icon} size={20} color={PrimaryColor} />
-      <Text style={[tailwind('mx-1'), PrimaryColorStyle.text]}>
+      <Text style={[tailwind('mx-1 uppercase'), PrimaryColorStyle.text]}>
         {translate('screens/BalancesScreen', props.title)}
       </Text>
     </TouchableOpacity>

--- a/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.tsx
+++ b/screens/AppNavigator/screens/BalancesScreen/BalancesScreen.tsx
@@ -1,28 +1,24 @@
 import { AddressToken } from '@defichain/whale-api-client/dist/api/address'
-import { MaterialCommunityIcons } from '@expo/vector-icons'
-import { NavigationProp } from '@react-navigation/native'
-import { useCallback, useState } from 'react'
+import { MaterialIcons } from '@expo/vector-icons'
+import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
-import { FlatList, RefreshControl, Text, TouchableOpacity, View } from 'react-native'
+import { useCallback, useState } from 'react'
+import { FlatList, RefreshControl, TouchableOpacity } from 'react-native'
+import NumberFormat from 'react-number-format'
 import { useDispatch, useSelector } from 'react-redux'
 import tailwind from 'tailwind-rn'
-import { NumberText } from '../../../../components'
-
+import { Text, View } from '../../../../components'
 import { getTokenIcon } from '../../../../components/icons/tokens/_index'
 import { PrimaryColor, PrimaryColorStyle } from '../../../../constants/Theme'
 import { useWhaleApiClient } from '../../../../hooks/api/useWhaleApiClient'
 import { fetchTokens, useTokensAPI } from '../../../../hooks/wallet/TokensAPI'
 import { RootState } from '../../../../store'
 import { translate } from '../../../../translations'
+import { BalanceParamList } from './BalancesNavigator'
 
-interface OperationButtonProps {
-  iconName: string | any
-  title: string
-  navigateTo: string
-  navigator: NavigationProp<any>
-}
+type Props = StackScreenProps<BalanceParamList, 'BalancesScreen'>
 
-export function BalancesScreen ({ navigation }: { navigation: NavigationProp<any> }): JSX.Element {
+export function BalancesScreen ({ navigation }: Props): JSX.Element {
   const address = useSelector((state: RootState) => state.wallet.address)
   const [refreshing, setRefreshing] = useState(false)
   const dispatch = useDispatch()
@@ -37,25 +33,25 @@ export function BalancesScreen ({ navigation }: { navigation: NavigationProp<any
   const tokens = useTokensAPI()
   return (
     <FlatList
-      data={tokens}
       testID='balances_list'
+      style={tailwind('bg-gray-100')}
       refreshControl={
-        <RefreshControl
-          refreshing={refreshing}
-          onRefresh={onRefresh}
-        />
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
       }
+      data={tokens}
       renderItem={({ item }) => <BalanceItemRow token={item} key={item.symbol} />}
+      ItemSeparatorComponent={() => <View style={tailwind('h-px bg-gray-100')} />}
       ListHeaderComponent={
-        <>
-          <View style={tailwind('flex flex-row p-3 bg-white border-b border-gray-200')}>
-            <OperationButton iconName='arrow-down' title='receive' navigateTo='receive' navigator={navigation} />
-            <OperationButton iconName='arrow-up' title='send' navigateTo='send' navigator={navigation} />
-          </View>
-          <Text testID='balances_title' style={tailwind('font-bold p-4 text-base')}>
-            {translate('screens/BalancesScreen', 'Portfolio')}
-          </Text>
-        </>
+        <View style={tailwind('flex-row justify-end px-4 py-3 bg-white border-b border-gray-200')}>
+          <BalanceActionButton
+            icon='arrow-downward' title='RECEIVE'
+            onPress={() => navigation.navigate('Receive')}
+          />
+          <BalanceActionButton
+            icon='arrow-upward' title='SEND'
+            onPress={() => navigation.navigate('Send')}
+          />
+        </View>
       }
     />
   )
@@ -63,37 +59,38 @@ export function BalancesScreen ({ navigation }: { navigation: NavigationProp<any
 
 function BalanceItemRow ({ token }: { token: AddressToken }): JSX.Element {
   const Icon = getTokenIcon(token.symbol)
-  const baseTestID = `balances_row_${token.id}`
+
   return (
-    <View testID={baseTestID} style={tailwind('bg-white p-2 border-b border-gray-200 flex-row items-center h-16')}>
-      <View style={tailwind('w-8')}>
-        <Icon testID={`${baseTestID}_icon`} />
+    <View testID='balance_item_row' style={tailwind('bg-white p-4 flex-row justify-between items-center')}>
+      <View style={tailwind('flex-row items-center')}>
+        <Icon />
+        <View style={tailwind('mx-3')}>
+          <Text>{token.symbol}</Text>
+          <Text style={tailwind('text-xs font-medium text-gray-600')}>{token.name}</Text>
+        </View>
       </View>
-      <View style={tailwind('flex flex-col ml-3')}>
-        <Text testID={`${baseTestID}_symbol`} style={tailwind('font-medium')}>{token.symbol}</Text>
-        <Text
-          testID={`${baseTestID}_name`}
-          style={tailwind('text-xs text-gray-400 overflow-hidden')}
-        >{token.name}
-        </Text>
-      </View>
-      <Text testID={`${baseTestID}_amount`} style={tailwind('flex-grow text-right font-medium overflow-hidden ml-3')}>
-        <NumberText value={token.amount} />
-      </Text>
+
+      <NumberFormat
+        value={token.amount} decimalScale={3} thousandSeparator displayType='text'
+        renderText={(value) => <Text>{value}</Text>}
+      />
     </View>
   )
 }
 
-function OperationButton (props: OperationButtonProps): JSX.Element {
+function BalanceActionButton (props: {
+  icon: React.ComponentProps<typeof MaterialIcons>['name']
+  title: string
+  onPress: () => void
+}): JSX.Element {
   return (
     <TouchableOpacity
-      testID={`button_${props.title}`} onPress={() => props.navigator.navigate(props.navigateTo)}
-      style={tailwind('px-2 py-1 border-2 border-gray-200 flex flex-row rounded-md uppercase mr-2.5')}
+      style={[tailwind('px-2 py-1.5 ml-3 flex-row items-center border border-gray-300 rounded')]}
+      onPress={props.onPress}
     >
-      <MaterialCommunityIcons style={tailwind('self-center')} name={props.iconName} size={16} color={PrimaryColor} />
-      <Text
-        style={[PrimaryColorStyle.text, tailwind('ml-1 text-sm font-medium uppercase')]}
-      >{translate('screens/BalancesScreen', props.title)}
+      <MaterialIcons name={props.icon} size={20} color={PrimaryColor} />
+      <Text style={[tailwind('mx-1'), PrimaryColorStyle.text]}>
+        {translate('screens/BalancesScreen', props.title)}
       </Text>
     </TouchableOpacity>
   )

--- a/screens/AppNavigator/screens/BalancesScreen/__snapshots__/BalancesScreen.test.tsx.snap
+++ b/screens/AppNavigator/screens/BalancesScreen/__snapshots__/BalancesScreen.test.tsx.snap
@@ -25,12 +25,12 @@ exports[`balances page should match snapshot 1`] = `
       <BalanceActionButton
         icon="arrow-downward"
         onPress={[Function]}
-        title="receive"
+        title="RECEIVE"
       />
       <BalanceActionButton
         icon="arrow-upward"
         onPress={[Function]}
-        title="send"
+        title="SEND"
       />
     </View>
   }
@@ -156,10 +156,9 @@ exports[`balances page should match snapshot 1`] = `
               "paddingLeft": 8,
               "paddingRight": 8,
               "paddingTop": 6,
-              "textTransform": "uppercase",
             }
           }
-          testID="button_receive"
+          testID="button_RECEIVE"
         >
           <Text />
           <Text
@@ -181,7 +180,7 @@ exports[`balances page should match snapshot 1`] = `
               ]
             }
           >
-            receive
+            RECEIVE
           </Text>
         </View>
         <View
@@ -216,10 +215,9 @@ exports[`balances page should match snapshot 1`] = `
               "paddingLeft": 8,
               "paddingRight": 8,
               "paddingTop": 6,
-              "textTransform": "uppercase",
             }
           }
-          testID="button_send"
+          testID="button_SEND"
         >
           <Text />
           <Text
@@ -241,7 +239,7 @@ exports[`balances page should match snapshot 1`] = `
               ]
             }
           >
-            send
+            SEND
           </Text>
         </View>
       </View>
@@ -265,7 +263,7 @@ exports[`balances page should match snapshot 1`] = `
             },
           ]
         }
-        testID="balance_item_row"
+        testID="balances_row_0"
       >
         <View
           style={
@@ -379,6 +377,7 @@ exports[`balances page should match snapshot 1`] = `
               undefined,
             ]
           }
+          testID="balances_row_0_amount"
         >
           23
         </Text>
@@ -413,7 +412,7 @@ exports[`balances page should match snapshot 1`] = `
             },
           ]
         }
-        testID="balance_item_row"
+        testID="balances_row_1"
       >
         <View
           style={
@@ -525,6 +524,7 @@ exports[`balances page should match snapshot 1`] = `
               undefined,
             ]
           }
+          testID="balances_row_1_amount"
         >
           777
         </Text>
@@ -559,7 +559,7 @@ exports[`balances page should match snapshot 1`] = `
             },
           ]
         }
-        testID="balance_item_row"
+        testID="balances_row_2"
       >
         <View
           style={
@@ -715,6 +715,7 @@ exports[`balances page should match snapshot 1`] = `
               undefined,
             ]
           }
+          testID="balances_row_2_amount"
         >
           555
         </Text>

--- a/screens/AppNavigator/screens/BalancesScreen/__snapshots__/BalancesScreen.test.tsx.snap
+++ b/screens/AppNavigator/screens/BalancesScreen/__snapshots__/BalancesScreen.test.tsx.snap
@@ -2,64 +2,37 @@
 
 exports[`balances page should match snapshot 1`] = `
 <RCTScrollView
+  ItemSeparatorComponent={[Function]}
   ListHeaderComponent={
-    <React.Fragment>
-      <View
-        style={
-          Object {
-            "backgroundColor": "rgba(255, 255, 255, 1)",
-            "borderBottomColor": "rgba(229, 231, 235, 1)",
-            "borderBottomWidth": 1,
-            "borderLeftColor": "rgba(229, 231, 235, 1)",
-            "borderRightColor": "rgba(229, 231, 235, 1)",
-            "borderTopColor": "rgba(229, 231, 235, 1)",
-            "display": "flex",
-            "flexDirection": "row",
-            "paddingBottom": 12,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 12,
-          }
+    <View
+      style={
+        Object {
+          "backgroundColor": "rgba(255, 255, 255, 1)",
+          "borderBottomColor": "rgba(229, 231, 235, 1)",
+          "borderBottomWidth": 1,
+          "borderLeftColor": "rgba(229, 231, 235, 1)",
+          "borderRightColor": "rgba(229, 231, 235, 1)",
+          "borderTopColor": "rgba(229, 231, 235, 1)",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "paddingBottom": 12,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 12,
         }
-      >
-        <OperationButton
-          iconName="arrow-down"
-          navigateTo="receive"
-          navigator={
-            Object {
-              "navigate": [MockFunction],
-            }
-          }
-          title="receive"
-        />
-        <OperationButton
-          iconName="arrow-up"
-          navigateTo="send"
-          navigator={
-            Object {
-              "navigate": [MockFunction],
-            }
-          }
-          title="send"
-        />
-      </View>
-      <Text
-        style={
-          Object {
-            "fontSize": 16,
-            "fontWeight": "700",
-            "lineHeight": 24,
-            "paddingBottom": 16,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-            "paddingTop": 16,
-          }
-        }
-        testID="balances_title"
-      >
-        Portfolio
-      </Text>
-    </React.Fragment>
+      }
+    >
+      <BalanceActionButton
+        icon="arrow-downward"
+        onPress={[Function]}
+        title="receive"
+      />
+      <BalanceActionButton
+        icon="arrow-upward"
+        onPress={[Function]}
+        title="send"
+      />
+    </View>
   }
   data={
     Array [
@@ -116,6 +89,11 @@ exports[`balances page should match snapshot 1`] = `
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
+  style={
+    Object {
+      "backgroundColor": "rgba(243, 244, 246, 1)",
+    }
+  }
   testID="balances_list"
   updateCellsBatchingPeriod={50}
   viewabilityConfigCallbackPairs={Array []}
@@ -128,20 +106,22 @@ exports[`balances page should match snapshot 1`] = `
     >
       <View
         style={
-          Object {
-            "backgroundColor": "rgba(255, 255, 255, 1)",
-            "borderBottomColor": "rgba(229, 231, 235, 1)",
-            "borderBottomWidth": 1,
-            "borderLeftColor": "rgba(229, 231, 235, 1)",
-            "borderRightColor": "rgba(229, 231, 235, 1)",
-            "borderTopColor": "rgba(229, 231, 235, 1)",
-            "display": "flex",
-            "flexDirection": "row",
-            "paddingBottom": 12,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 12,
-          }
+          Array [
+            Object {
+              "backgroundColor": "rgba(255, 255, 255, 1)",
+              "borderBottomColor": "rgba(229, 231, 235, 1)",
+              "borderBottomWidth": 1,
+              "borderLeftColor": "rgba(229, 231, 235, 1)",
+              "borderRightColor": "rgba(229, 231, 235, 1)",
+              "borderTopColor": "rgba(229, 231, 235, 1)",
+              "flexDirection": "row",
+              "justifyContent": "flex-end",
+              "paddingBottom": 12,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 12,
+            },
+          ]
         }
       >
         <View
@@ -156,26 +136,26 @@ exports[`balances page should match snapshot 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             Object {
-              "borderBottomColor": "rgba(229, 231, 235, 1)",
-              "borderBottomLeftRadius": 6,
-              "borderBottomRightRadius": 6,
-              "borderBottomWidth": 2,
-              "borderLeftColor": "rgba(229, 231, 235, 1)",
-              "borderLeftWidth": 2,
-              "borderRightColor": "rgba(229, 231, 235, 1)",
-              "borderRightWidth": 2,
-              "borderTopColor": "rgba(229, 231, 235, 1)",
-              "borderTopLeftRadius": 6,
-              "borderTopRightRadius": 6,
-              "borderTopWidth": 2,
-              "display": "flex",
+              "alignItems": "center",
+              "borderBottomColor": "rgba(209, 213, 219, 1)",
+              "borderBottomLeftRadius": 4,
+              "borderBottomRightRadius": 4,
+              "borderBottomWidth": 1,
+              "borderLeftColor": "rgba(209, 213, 219, 1)",
+              "borderLeftWidth": 1,
+              "borderRightColor": "rgba(209, 213, 219, 1)",
+              "borderRightWidth": 1,
+              "borderTopColor": "rgba(209, 213, 219, 1)",
+              "borderTopLeftRadius": 4,
+              "borderTopRightRadius": 4,
+              "borderTopWidth": 1,
               "flexDirection": "row",
-              "marginRight": 10,
+              "marginLeft": 12,
               "opacity": 1,
-              "paddingBottom": 4,
+              "paddingBottom": 6,
               "paddingLeft": 8,
               "paddingRight": 8,
-              "paddingTop": 4,
+              "paddingTop": 6,
               "textTransform": "uppercase",
             }
           }
@@ -186,15 +166,18 @@ exports[`balances page should match snapshot 1`] = `
             style={
               Array [
                 Object {
-                  "color": "#ff00af",
+                  "fontSize": 16,
+                  "fontWeight": "600",
                 },
-                Object {
-                  "fontSize": 14,
-                  "fontWeight": "500",
-                  "lineHeight": 20,
-                  "marginLeft": 4,
-                  "textTransform": "uppercase",
-                },
+                Array [
+                  Object {
+                    "marginLeft": 4,
+                    "marginRight": 4,
+                  },
+                  Object {
+                    "color": "#ff00af",
+                  },
+                ],
               ]
             }
           >
@@ -213,26 +196,26 @@ exports[`balances page should match snapshot 1`] = `
           onStartShouldSetResponder={[Function]}
           style={
             Object {
-              "borderBottomColor": "rgba(229, 231, 235, 1)",
-              "borderBottomLeftRadius": 6,
-              "borderBottomRightRadius": 6,
-              "borderBottomWidth": 2,
-              "borderLeftColor": "rgba(229, 231, 235, 1)",
-              "borderLeftWidth": 2,
-              "borderRightColor": "rgba(229, 231, 235, 1)",
-              "borderRightWidth": 2,
-              "borderTopColor": "rgba(229, 231, 235, 1)",
-              "borderTopLeftRadius": 6,
-              "borderTopRightRadius": 6,
-              "borderTopWidth": 2,
-              "display": "flex",
+              "alignItems": "center",
+              "borderBottomColor": "rgba(209, 213, 219, 1)",
+              "borderBottomLeftRadius": 4,
+              "borderBottomRightRadius": 4,
+              "borderBottomWidth": 1,
+              "borderLeftColor": "rgba(209, 213, 219, 1)",
+              "borderLeftWidth": 1,
+              "borderRightColor": "rgba(209, 213, 219, 1)",
+              "borderRightWidth": 1,
+              "borderTopColor": "rgba(209, 213, 219, 1)",
+              "borderTopLeftRadius": 4,
+              "borderTopRightRadius": 4,
+              "borderTopWidth": 1,
               "flexDirection": "row",
-              "marginRight": 10,
+              "marginLeft": 12,
               "opacity": 1,
-              "paddingBottom": 4,
+              "paddingBottom": 6,
               "paddingLeft": 8,
               "paddingRight": 8,
-              "paddingTop": 4,
+              "paddingTop": 6,
               "textTransform": "uppercase",
             }
           }
@@ -243,15 +226,18 @@ exports[`balances page should match snapshot 1`] = `
             style={
               Array [
                 Object {
-                  "color": "#ff00af",
+                  "fontSize": 16,
+                  "fontWeight": "600",
                 },
-                Object {
-                  "fontSize": 14,
-                  "fontWeight": "500",
-                  "lineHeight": 20,
-                  "marginLeft": 4,
-                  "textTransform": "uppercase",
-                },
+                Array [
+                  Object {
+                    "marginLeft": 4,
+                    "marginRight": 4,
+                  },
+                  Object {
+                    "color": "#ff00af",
+                  },
+                ],
               ]
             }
           >
@@ -259,22 +245,6 @@ exports[`balances page should match snapshot 1`] = `
           </Text>
         </View>
       </View>
-      <Text
-        style={
-          Object {
-            "fontSize": 16,
-            "fontWeight": "700",
-            "lineHeight": 24,
-            "paddingBottom": 16,
-            "paddingLeft": 16,
-            "paddingRight": 16,
-            "paddingTop": 16,
-          }
-        }
-        testID="balances_title"
-      >
-        Portfolio
-      </Text>
     </View>
     <View
       onLayout={[Function]}
@@ -282,29 +252,29 @@ exports[`balances page should match snapshot 1`] = `
     >
       <View
         style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "rgba(255, 255, 255, 1)",
-            "borderBottomColor": "rgba(229, 231, 235, 1)",
-            "borderBottomWidth": 1,
-            "borderLeftColor": "rgba(229, 231, 235, 1)",
-            "borderRightColor": "rgba(229, 231, 235, 1)",
-            "borderTopColor": "rgba(229, 231, 235, 1)",
-            "flexDirection": "row",
-            "height": 64,
-            "paddingBottom": 8,
-            "paddingLeft": 8,
-            "paddingRight": 8,
-            "paddingTop": 8,
-          }
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255, 255, 255, 1)",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "paddingBottom": 16,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 16,
+            },
+          ]
         }
-        testID="balances_row_0"
+        testID="balance_item_row"
       >
         <View
           style={
-            Object {
-              "width": 32,
-            }
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <RNSVGSvgView
@@ -329,7 +299,6 @@ exports[`balances page should match snapshot 1`] = `
                 },
               ]
             }
-            testID="balances_row_0_icon"
             vbHeight={32}
             vbWidth={32}
             width={32}
@@ -357,67 +326,73 @@ exports[`balances page should match snapshot 1`] = `
               />
             </RNSVGGroup>
           </RNSVGSvgView>
-        </View>
-        <View
-          style={
-            Object {
-              "display": "flex",
-              "flexDirection": "column",
-              "marginLeft": 12,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "500",
-              }
-            }
-            testID="balances_row_0_symbol"
-          >
-            DFI
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "rgba(156, 163, 175, 1)",
-                "fontSize": 12,
-                "lineHeight": 16,
-                "overflow": "hidden",
-              }
-            }
-            testID="balances_row_0_name"
-          >
-            Defi
-          </Text>
-        </View>
-        <Text
-          style={
-            Object {
-              "flexGrow": 1,
-              "fontWeight": "500",
-              "marginLeft": 12,
-              "overflow": "hidden",
-              "textAlign": "right",
-            }
-          }
-          testID="balances_row_0_amount"
-        >
-          <Text
+          <View
             style={
               Array [
                 Object {
-                  "fontSize": 16,
-                  "fontWeight": "600",
+                  "marginLeft": 12,
+                  "marginRight": 12,
                 },
-                undefined,
               ]
             }
           >
-            23
-          </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 16,
+                    "fontWeight": "600",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              DFI
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 16,
+                    "fontWeight": "600",
+                  },
+                  Object {
+                    "color": "rgba(75, 85, 99, 1)",
+                    "fontSize": 12,
+                    "fontWeight": "500",
+                    "lineHeight": 16,
+                  },
+                ]
+              }
+            >
+              Defi
+            </Text>
+          </View>
+        </View>
+        <Text
+          style={
+            Array [
+              Object {
+                "fontSize": 16,
+                "fontWeight": "600",
+              },
+              undefined,
+            ]
+          }
+        >
+          23
         </Text>
       </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgba(243, 244, 246, 1)",
+              "height": 1,
+            },
+          ]
+        }
+      />
     </View>
     <View
       onLayout={[Function]}
@@ -425,29 +400,29 @@ exports[`balances page should match snapshot 1`] = `
     >
       <View
         style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "rgba(255, 255, 255, 1)",
-            "borderBottomColor": "rgba(229, 231, 235, 1)",
-            "borderBottomWidth": 1,
-            "borderLeftColor": "rgba(229, 231, 235, 1)",
-            "borderRightColor": "rgba(229, 231, 235, 1)",
-            "borderTopColor": "rgba(229, 231, 235, 1)",
-            "flexDirection": "row",
-            "height": 64,
-            "paddingBottom": 8,
-            "paddingLeft": 8,
-            "paddingRight": 8,
-            "paddingTop": 8,
-          }
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255, 255, 255, 1)",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "paddingBottom": 16,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 16,
+            },
+          ]
         }
-        testID="balances_row_1"
+        testID="balance_item_row"
       >
         <View
           style={
-            Object {
-              "width": 32,
-            }
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <RNSVGSvgView
@@ -472,7 +447,6 @@ exports[`balances page should match snapshot 1`] = `
                 },
               ]
             }
-            testID="balances_row_1_icon"
             vbHeight={32}
             vbWidth={32}
             width={32}
@@ -498,67 +472,73 @@ exports[`balances page should match snapshot 1`] = `
               />
             </RNSVGGroup>
           </RNSVGSvgView>
-        </View>
-        <View
-          style={
-            Object {
-              "display": "flex",
-              "flexDirection": "column",
-              "marginLeft": 12,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "500",
-              }
-            }
-            testID="balances_row_1_symbol"
-          >
-            BTC
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "rgba(156, 163, 175, 1)",
-                "fontSize": 12,
-                "lineHeight": 16,
-                "overflow": "hidden",
-              }
-            }
-            testID="balances_row_1_name"
-          >
-            Bitcoin
-          </Text>
-        </View>
-        <Text
-          style={
-            Object {
-              "flexGrow": 1,
-              "fontWeight": "500",
-              "marginLeft": 12,
-              "overflow": "hidden",
-              "textAlign": "right",
-            }
-          }
-          testID="balances_row_1_amount"
-        >
-          <Text
+          <View
             style={
               Array [
                 Object {
-                  "fontSize": 16,
-                  "fontWeight": "600",
+                  "marginLeft": 12,
+                  "marginRight": 12,
                 },
-                undefined,
               ]
             }
           >
-            777
-          </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 16,
+                    "fontWeight": "600",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              BTC
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 16,
+                    "fontWeight": "600",
+                  },
+                  Object {
+                    "color": "rgba(75, 85, 99, 1)",
+                    "fontSize": 12,
+                    "fontWeight": "500",
+                    "lineHeight": 16,
+                  },
+                ]
+              }
+            >
+              Bitcoin
+            </Text>
+          </View>
+        </View>
+        <Text
+          style={
+            Array [
+              Object {
+                "fontSize": 16,
+                "fontWeight": "600",
+              },
+              undefined,
+            ]
+          }
+        >
+          777
         </Text>
       </View>
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgba(243, 244, 246, 1)",
+              "height": 1,
+            },
+          ]
+        }
+      />
     </View>
     <View
       onLayout={[Function]}
@@ -566,29 +546,29 @@ exports[`balances page should match snapshot 1`] = `
     >
       <View
         style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "rgba(255, 255, 255, 1)",
-            "borderBottomColor": "rgba(229, 231, 235, 1)",
-            "borderBottomWidth": 1,
-            "borderLeftColor": "rgba(229, 231, 235, 1)",
-            "borderRightColor": "rgba(229, 231, 235, 1)",
-            "borderTopColor": "rgba(229, 231, 235, 1)",
-            "flexDirection": "row",
-            "height": 64,
-            "paddingBottom": 8,
-            "paddingLeft": 8,
-            "paddingRight": 8,
-            "paddingTop": 8,
-          }
+          Array [
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "rgba(255, 255, 255, 1)",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "paddingBottom": 16,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 16,
+            },
+          ]
         }
-        testID="balances_row_2"
+        testID="balance_item_row"
       >
         <View
           style={
-            Object {
-              "width": 32,
-            }
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+              },
+            ]
           }
         >
           <RNSVGSvgView
@@ -613,7 +593,6 @@ exports[`balances page should match snapshot 1`] = `
                 },
               ]
             }
-            testID="balances_row_2_icon"
             vbHeight={32}
             vbWidth={32}
             width={32}
@@ -683,65 +662,61 @@ exports[`balances page should match snapshot 1`] = `
               </RNSVGGroup>
             </RNSVGGroup>
           </RNSVGSvgView>
-        </View>
-        <View
-          style={
-            Object {
-              "display": "flex",
-              "flexDirection": "column",
-              "marginLeft": 12,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "500",
-              }
-            }
-            testID="balances_row_2_symbol"
-          >
-            ETH
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "rgba(156, 163, 175, 1)",
-                "fontSize": 12,
-                "lineHeight": 16,
-                "overflow": "hidden",
-              }
-            }
-            testID="balances_row_2_name"
-          >
-            Ethereum
-          </Text>
-        </View>
-        <Text
-          style={
-            Object {
-              "flexGrow": 1,
-              "fontWeight": "500",
-              "marginLeft": 12,
-              "overflow": "hidden",
-              "textAlign": "right",
-            }
-          }
-          testID="balances_row_2_amount"
-        >
-          <Text
+          <View
             style={
               Array [
                 Object {
-                  "fontSize": 16,
-                  "fontWeight": "600",
+                  "marginLeft": 12,
+                  "marginRight": 12,
                 },
-                undefined,
               ]
             }
           >
-            555
-          </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 16,
+                    "fontWeight": "600",
+                  },
+                  undefined,
+                ]
+              }
+            >
+              ETH
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 16,
+                    "fontWeight": "600",
+                  },
+                  Object {
+                    "color": "rgba(75, 85, 99, 1)",
+                    "fontSize": 12,
+                    "fontWeight": "500",
+                    "lineHeight": 16,
+                  },
+                ]
+              }
+            >
+              Ethereum
+            </Text>
+          </View>
+        </View>
+        <Text
+          style={
+            Array [
+              Object {
+                "fontSize": 16,
+                "fontWeight": "600",
+              },
+              undefined,
+            ]
+          }
+        >
+          555
         </Text>
       </View>
     </View>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

- Added missing BalancesNavigator props
- Used MaterialIcons instead of Community which isn't natively cached
- Used `./components` instead of react-native for `Text`, `View` for future dark theme-ing
- Deprecated NumberText use
- Used explicit React Props for Navigation
- Used the correct separator design pattern
- Influence/use style from top-level flex concepts instead of individual styling flex items
- Removed the use of `testID` for each subcomponent, they should only be done at the root level component
- Instead of passing referencing into component, exposed a closure of non-side-effect coding
- Updated design to be more resilient towards screen fragmentation

@thedoublejay help me fix the tests and merge this PR in