### PR TITLE
added environment and network prefixed storage

### DIFF
--- a/app/storage.test.ts
+++ b/app/storage.test.ts
@@ -1,0 +1,34 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { EnvironmentNetwork } from "./environment";
+import { getNetwork, setNetwork } from "./storage";
+
+const getItem = jest.spyOn(AsyncStorage, 'getItem')
+const setItem = jest.spyOn(AsyncStorage, 'setItem')
+
+describe('network', () => {
+  it('should default to Remote Playground', async () => {
+    getItem.mockClear()
+    expect(await getNetwork()).toBe(EnvironmentNetwork.RemotePlayground)
+    expect(getItem).toBeCalled()
+  });
+
+  it('should call setItem', async () => {
+    await setNetwork(EnvironmentNetwork.RemotePlayground)
+    expect(setItem).toBeCalled()
+  });
+
+  it('should get Local Playground', async () => {
+    getItem.mockResolvedValue(EnvironmentNetwork.LocalPlayground)
+    expect(await getNetwork()).toBe(EnvironmentNetwork.LocalPlayground)
+  });
+
+  it('should get Local Playground', async () => {
+    getItem.mockResolvedValue(EnvironmentNetwork.RemotePlayground)
+    expect(await getNetwork()).toBe(EnvironmentNetwork.RemotePlayground)
+  });
+
+  it('should errored as network is not part of environment', async () => {
+    await expect(setNetwork(EnvironmentNetwork.MainNet))
+      .rejects.toThrow('network is not part of environment')
+  });
+})

--- a/app/storage.test.ts
+++ b/app/storage.test.ts
@@ -1,34 +1,61 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { EnvironmentNetwork } from "./environment";
-import { getNetwork, setNetwork } from "./storage";
+import * as storage from "./storage";
 
 const getItem = jest.spyOn(AsyncStorage, 'getItem')
 const setItem = jest.spyOn(AsyncStorage, 'setItem')
+const removeItem = jest.spyOn(AsyncStorage, 'removeItem')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 describe('network', () => {
   it('should default to Remote Playground', async () => {
-    getItem.mockClear()
-    expect(await getNetwork()).toBe(EnvironmentNetwork.RemotePlayground)
+    expect(await storage.getNetwork()).toBe(EnvironmentNetwork.RemotePlayground)
     expect(getItem).toBeCalled()
   });
 
   it('should call setItem', async () => {
-    await setNetwork(EnvironmentNetwork.RemotePlayground)
+    await storage.setNetwork(EnvironmentNetwork.RemotePlayground)
     expect(setItem).toBeCalled()
   });
 
   it('should get Local Playground', async () => {
     getItem.mockResolvedValue(EnvironmentNetwork.LocalPlayground)
-    expect(await getNetwork()).toBe(EnvironmentNetwork.LocalPlayground)
+    expect(await storage.getNetwork()).toBe(EnvironmentNetwork.LocalPlayground)
   });
 
   it('should get Local Playground', async () => {
     getItem.mockResolvedValue(EnvironmentNetwork.RemotePlayground)
-    expect(await getNetwork()).toBe(EnvironmentNetwork.RemotePlayground)
+    expect(await storage.getNetwork()).toBe(EnvironmentNetwork.RemotePlayground)
   });
 
   it('should errored as network is not part of environment', async () => {
-    await expect(setNetwork(EnvironmentNetwork.MainNet))
+    await expect(storage.setNetwork(EnvironmentNetwork.MainNet))
       .rejects.toThrow('network is not part of environment')
   });
+})
+
+describe('item', () => {
+  beforeEach(() => {
+    getItem.mockResolvedValue(EnvironmentNetwork.RemotePlayground)
+  })
+
+  it('should getItem with environment and network prefixed key', async () => {
+    await storage.getItem('get')
+    expect(getItem).toBeCalledTimes(2)
+    expect(getItem).toBeCalledWith('Development.NETWORK')
+    expect(getItem).toBeCalledWith('Development.Remote Playground.get')
+  })
+
+  it('should setItem with environment and network prefixed key', async () => {
+    await storage.setItem('set', 'value')
+    expect(setItem).toBeCalledWith('Development.Remote Playground.set', 'value')
+  })
+
+  it('should removeItem with environment and network prefixed key', async () => {
+    await storage.removeItem('remove')
+    expect(removeItem).toBeCalledWith('Development.Remote Playground.remove')
+  })
 })

--- a/app/storage.ts
+++ b/app/storage.ts
@@ -1,0 +1,59 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { EnvironmentNetwork, getEnvironment } from './environment'
+
+/**
+ * @return EnvironmentNetwork if invalid, will be set to `networks[0]`
+ */
+export async function getNetwork (): Promise<EnvironmentNetwork> {
+  const env = getEnvironment()
+  const network = await AsyncStorage.getItem(`${env.name}.NETWORK`)
+
+  if ((env.networks as any[]).includes(network)) {
+    return network as EnvironmentNetwork
+  }
+
+  await setNetwork(env.networks[0])
+  return env.networks[0]
+}
+
+/**
+ * @param network {EnvironmentNetwork} with set with 'environment' prefixed
+ */
+export async function setNetwork (network: EnvironmentNetwork): Promise<void> {
+  const env = getEnvironment()
+
+  if (!env.networks.includes(network)) {
+    throw new Error('network is not part of environment')
+  }
+
+  await AsyncStorage.setItem(`${env.name}.NETWORK`, network)
+}
+
+async function getKey (key: string): Promise<string> {
+  const env = getEnvironment()
+  const network = await getNetwork()
+  return `${env.name}.${network}.${key}`
+}
+
+/**
+ * @param key {string} of item with 'environment' and 'network' prefixed
+ * @return {string | null}
+ */
+export async function getItem (key: string): Promise<string | null> {
+  return await AsyncStorage.getItem(await getKey(key))
+}
+
+/**
+ * @param key {string} of item with 'environment' and 'network' prefixed
+ * @param value {string} to set
+ */
+export async function setItem (key: string, value: string): Promise<void> {
+  return await AsyncStorage.setItem(await getKey(key), value)
+}
+
+/**
+ * @param key {string} of item with 'environment' and 'network' prefixed
+ */
+export async function removeItem (key: string): Promise<void> {
+  await AsyncStorage.removeItem(await getKey(key))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Environment and network prefixed storage for network and environment-independent settings.
Created so that we don't accidentally leak secrets between evironments.