### PR TITLE
`whale` and `playground` client abstracted from UI logic

### DIFF
--- a/app/api/playground.test.ts
+++ b/app/api/playground.test.ts
@@ -1,0 +1,53 @@
+import { PlaygroundApiClient } from "@defichain/playground-api-client";
+import { renderHook } from '@testing-library/react-hooks'
+import { waitFor } from "@testing-library/react-native";
+import { EnvironmentNetwork } from "../environment";
+import { Logging } from "../logging";
+import { getNetwork } from "../storage";
+import { getPlaygroundClient, useCachedPlaygroundClient } from "./playground";
+
+jest.mock('@defichain/playground-api-client')
+jest.mock('../storage')
+jest.spyOn(console, 'log').mockImplementation(jest.fn)
+const error = jest.spyOn(Logging, 'error')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+it('should load RemotePlayground', async () => {
+  (getNetwork as jest.Mock).mockResolvedValue(EnvironmentNetwork.RemotePlayground)
+
+  const { result } = renderHook(() => useCachedPlaygroundClient())
+  await waitFor(() => {
+    expect(result.current).toBeTruthy()
+  })
+
+  expect(getPlaygroundClient()).toBeDefined()
+  expect(PlaygroundApiClient).toBeCalledWith({
+    url: "https://playground.defichain.com"
+  })
+})
+
+it('should load LocalPlayground', async () => {
+  (getNetwork as jest.Mock).mockResolvedValue(EnvironmentNetwork.LocalPlayground)
+
+  const { result } = renderHook(() => useCachedPlaygroundClient())
+  await waitFor(() => {
+    expect(result.current).toBeTruthy()
+  })
+
+  expect(getPlaygroundClient()).toBeDefined()
+  expect(PlaygroundApiClient).toBeCalledWith({
+    url: "http://localhost:19553"
+  })
+})
+
+it('should load MainNet but playground not available', async () => {
+  (getNetwork as jest.Mock).mockResolvedValue(EnvironmentNetwork.MainNet)
+
+  renderHook(() => useCachedPlaygroundClient())
+  await waitFor(() => {
+    expect(error).toBeCalled()
+  })
+})

--- a/app/api/playground.ts
+++ b/app/api/playground.ts
@@ -1,0 +1,41 @@
+import { PlaygroundApiClient } from '@defichain/playground-api-client'
+import { useEffect, useState } from 'react'
+import { EnvironmentNetwork } from '../environment'
+import { Logging } from '../logging'
+import { getNetwork } from '../storage'
+
+let SINGLETON: PlaygroundApiClient | undefined
+
+export function useCachedPlaygroundClient (): boolean {
+  const [isLoaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    newPlaygroundClient().then((client) => {
+      SINGLETON = client
+      setLoaded(true)
+    }).catch(Logging.error)
+  }, [])
+
+  return isLoaded
+}
+
+export function getPlaygroundClient (): PlaygroundApiClient {
+  if (SINGLETON !== undefined) {
+    return SINGLETON
+  }
+
+  throw new Error('useCachedPlaygroundClient() === true, hooks must be called before getPlaygroundClient()')
+}
+
+async function newPlaygroundClient (): Promise<PlaygroundApiClient> {
+  const network = await getNetwork()
+
+  switch (network) {
+    case EnvironmentNetwork.RemotePlayground:
+      return new PlaygroundApiClient({ url: 'https://playground.defichain.com' })
+    case EnvironmentNetwork.LocalPlayground:
+      return new PlaygroundApiClient({ url: 'http://localhost:19553' })
+    default:
+      throw new Error(`playground not available for '${network}'`)
+  }
+}

--- a/app/api/whale.test.ts
+++ b/app/api/whale.test.ts
@@ -1,0 +1,73 @@
+import { WhaleApiClient } from "@defichain/whale-api-client";
+import { renderHook } from '@testing-library/react-hooks'
+import { waitFor } from "@testing-library/react-native";
+import { EnvironmentNetwork } from "../environment";
+import { getNetwork } from "../storage";
+import { getWhaleClient, useCachedWhaleClient } from "./whale";
+
+jest.mock('@defichain/whale-api-client')
+jest.mock('../storage')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+it('should load MainNet', async () => {
+  (getNetwork as jest.Mock).mockResolvedValue(EnvironmentNetwork.MainNet)
+
+  const { result } = renderHook(() => useCachedWhaleClient())
+  await waitFor(() => {
+    expect(result.current).toBeTruthy()
+  })
+
+  expect(getWhaleClient()).toBeDefined()
+  expect(WhaleApiClient).toBeCalledWith({
+    network: "mainnet",
+    url: "https://ocean.defichain.com"
+  })
+})
+
+it('should load TestNet', async () => {
+  (getNetwork as jest.Mock).mockResolvedValue(EnvironmentNetwork.TestNet)
+
+  const { result } = renderHook(() => useCachedWhaleClient())
+  await waitFor(() => {
+    expect(result.current).toBeTruthy()
+  })
+
+  expect(getWhaleClient()).toBeDefined()
+  expect(WhaleApiClient).toBeCalledWith({
+    network: "testnet",
+    url: "https://ocean.defichain.com"
+  })
+})
+
+it('should load RemotePlayground', async () => {
+  (getNetwork as jest.Mock).mockResolvedValue(EnvironmentNetwork.RemotePlayground)
+
+  const { result } = renderHook(() => useCachedWhaleClient())
+  await waitFor(() => {
+    expect(result.current).toBeTruthy()
+  })
+
+  expect(getWhaleClient()).toBeDefined()
+  expect(WhaleApiClient).toBeCalledWith({
+    network: "regtest",
+    url: "https://playground.defichain.com"
+  })
+})
+
+it('should load LocalPlayground', async () => {
+  (getNetwork as jest.Mock).mockResolvedValue(EnvironmentNetwork.LocalPlayground)
+
+  const { result } = renderHook(() => useCachedWhaleClient())
+  await waitFor(() => {
+    expect(result.current).toBeTruthy()
+  })
+
+  expect(getWhaleClient()).toBeDefined()
+  expect(WhaleApiClient).toBeCalledWith({
+    network: "regtest",
+    url: "http://localhost:19553"
+  })
+})

--- a/app/api/whale.ts
+++ b/app/api/whale.ts
@@ -1,0 +1,43 @@
+import { WhaleApiClient } from '@defichain/whale-api-client'
+import { useEffect, useState } from 'react'
+import { EnvironmentNetwork } from '../environment'
+import { Logging } from '../logging'
+import { getNetwork } from '../storage'
+
+let SINGLETON: WhaleApiClient | undefined
+
+export function useCachedWhaleClient (): boolean {
+  const [isLoaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    newWhaleClient().then((client) => {
+      SINGLETON = client
+      setLoaded(true)
+    }).catch(Logging.error)
+  }, [])
+
+  return isLoaded
+}
+
+export function getWhaleClient (): WhaleApiClient {
+  if (SINGLETON !== undefined) {
+    return SINGLETON
+  }
+
+  throw new Error('useCachedWhaleClient() === true, hooks must be called before getWhaleClient()')
+}
+
+async function newWhaleClient (): Promise<WhaleApiClient> {
+  const network = await getNetwork()
+
+  switch (network) {
+    case EnvironmentNetwork.MainNet:
+      return new WhaleApiClient({ url: 'https://ocean.defichain.com', network: 'mainnet' })
+    case EnvironmentNetwork.TestNet:
+      return new WhaleApiClient({ url: 'https://ocean.defichain.com', network: 'testnet' })
+    case EnvironmentNetwork.RemotePlayground:
+      return new WhaleApiClient({ url: 'https://playground.defichain.com', network: 'regtest' })
+    case EnvironmentNetwork.LocalPlayground:
+      return new WhaleApiClient({ url: 'http://localhost:19553', network: 'regtest' })
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
       },
       "devDependencies": {
         "@babel/core": "~7.9.0",
+        "@testing-library/react-hooks": "^7.0.0",
         "@testing-library/react-native": "^7.2.0",
         "@types/find-in-files": "^0.5.1",
         "@types/i18n-js": "^3.8.0",
@@ -5767,6 +5768,47 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.0.tgz",
+      "integrity": "sha512-WFBGH8DWdIGGBHt6PBtQPe2v4Kbj9vQ1sQ9qLBTmwn1PNggngint4MTE/IiWCYhPbyTW3oc/7X62DObMn/AjQQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0",
+        "react-test-renderer": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-hooks/node_modules/@babel/runtime": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@testing-library/react-native": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-7.2.0.tgz",
@@ -6032,6 +6074,15 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.8.tgz",
+      "integrity": "sha512-0ohAiJAx1DAUEcY9UopnfwCE9sSMDGnY/oXjWMax6g3RpzmTt2GMyMVAXcbn0mo8XAff0SbQJl2/SBU+hjSZ1A==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-native": {
@@ -27317,6 +27368,34 @@
         "react": "^16.13.1"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
+      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-error-boundary/node_modules/@babel/runtime": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
@@ -39813,6 +39892,30 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.0.tgz",
+      "integrity": "sha512-WFBGH8DWdIGGBHt6PBtQPe2v4Kbj9vQ1sQ9qLBTmwn1PNggngint4MTE/IiWCYhPbyTW3oc/7X62DObMn/AjQQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@testing-library/react-native": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-7.2.0.tgz",
@@ -40067,6 +40170,15 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.8.tgz",
+      "integrity": "sha512-0ohAiJAx1DAUEcY9UopnfwCE9sSMDGnY/oXjWMax6g3RpzmTt2GMyMVAXcbn0mo8XAff0SbQJl2/SBU+hjSZ1A==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-native": {
@@ -56851,6 +56963,26 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
+      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",
+    "@testing-library/react-hooks": "^7.0.0",
     "@testing-library/react-native": "^7.2.0",
     "@types/find-in-files": "^0.5.1",
     "@types/i18n-js": "^3.8.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Added `whale` and `playground` client that doesn't use the redux store to hold their state. With this, it allows for stateless/storeless use cases. This also moves app logic from UI logic.

#### Additional notes:

Tests are written independently but not wiring with UI yet. stateless/storeless wallet will be written before wiring up the UI logic.