### PR TITLE
Environment and Network independent Wallet

### DIFF
--- a/app/wallet/index.test.ts
+++ b/app/wallet/index.test.ts
@@ -1,0 +1,92 @@
+import { OP_CODES } from "@defichain/jellyfish-transaction";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { renderHook } from "@testing-library/react-hooks";
+import { waitFor } from "@testing-library/react-native";
+import { useCachedWhaleClient } from "../api/whale";
+import { EnvironmentNetwork } from "../environment";
+import { Logging } from "../logging";
+import { getWallet, useCachedWallet } from "./index";
+
+const getItem = jest.spyOn(AsyncStorage, 'getItem')
+jest.spyOn(console, 'log').mockImplementation(jest.fn)
+const error = jest.spyOn(Logging, 'error')
+
+beforeEach(async () => {
+  jest.clearAllMocks()
+
+  const { result } = renderHook(() => useCachedWhaleClient())
+  await waitFor(() => {
+    expect(result.current).toBeTruthy()
+  })
+})
+
+it('should load account 0 with withTransactionBuilder', async () => {
+  getItem
+    .mockResolvedValueOnce(EnvironmentNetwork.LocalPlayground)
+    .mockResolvedValueOnce('408b285c123836004f4b8842c89324c1f01382450c0d439af345ba7fc49acf705489c6fc77dbd4e3dc1dd8cc6bc9f043db8ada1e243c4a0eafb290d399480840')
+
+  const { result } = renderHook(() => useCachedWallet())
+  await waitFor(() => {
+    expect(result).toBeTruthy()
+  })
+
+  expect(getWallet().get(0).withTransactionBuilder().utxo).toBeDefined()
+  expect(getWallet().get(0).withTransactionBuilder().dex).toBeDefined()
+  expect(getWallet().get(0).withTransactionBuilder().account).toBeDefined()
+  expect(getWallet().get(0).withTransactionBuilder().liqPool).toBeDefined()
+});
+
+it('should load LocalPlayground with (abandon x23) with expected keys', async () => {
+  getItem
+    .mockResolvedValueOnce(EnvironmentNetwork.LocalPlayground)
+    .mockResolvedValueOnce('408b285c123836004f4b8842c89324c1f01382450c0d439af345ba7fc49acf705489c6fc77dbd4e3dc1dd8cc6bc9f043db8ada1e243c4a0eafb290d399480840')
+
+  const { result } = renderHook(() => useCachedWallet())
+  await waitFor(() => {
+    expect(result).toBeTruthy()
+  })
+
+  expect(getWallet()).toBeDefined()
+  expect(await getWallet().get(0).getAddress()).toStrictEqual('bcrt1qynxwmwauztnzzar2nddh8hyhe3l7v5p3f7dn4c')
+  expect(await getWallet().get(0).getScript()).toStrictEqual({
+    stack: [
+      OP_CODES.OP_0,
+      OP_CODES.OP_PUSHDATA_HEX_LE('24ccedbbbc12e621746a9b5b73dc97cc7fe65031'),
+    ]
+  })
+
+  expect(await getWallet().get(1).getAddress()).toStrictEqual('bcrt1q4qv0q69rzfqy5wc74wpjgu0y2u9jyyggrrx3gn')
+  expect(await getWallet().get(1).getScript()).toStrictEqual({
+    stack: [
+      OP_CODES.OP_0,
+      OP_CODES.OP_PUSHDATA_HEX_LE('a818f068a312404a3b1eab832471e4570b221108'),
+    ]
+  })
+})
+
+it('should load RemotePlayground with (abandon x23) with expected keys', async () => {
+  getItem
+    .mockResolvedValueOnce(EnvironmentNetwork.RemotePlayground)
+    .mockResolvedValueOnce('408b285c123836004f4b8842c89324c1f01382450c0d439af345ba7fc49acf705489c6fc77dbd4e3dc1dd8cc6bc9f043db8ada1e243c4a0eafb290d399480840')
+
+  const { result } = renderHook(() => useCachedWallet())
+  await waitFor(() => {
+    expect(result).toBeTruthy()
+  })
+
+  expect(getWallet()).toBeDefined()
+  expect(await getWallet().get(0).getAddress()).toStrictEqual('bcrt1qynxwmwauztnzzar2nddh8hyhe3l7v5p3f7dn4c')
+  expect(await getWallet().get(1).getAddress()).toStrictEqual('bcrt1q4qv0q69rzfqy5wc74wpjgu0y2u9jyyggrrx3gn')
+})
+
+it('should fail without having any seed stored', async () => {
+  getItem
+    .mockResolvedValueOnce(EnvironmentNetwork.LocalPlayground)
+    .mockResolvedValueOnce(null)
+
+  await renderHook(() => useCachedWallet()).waitFor(() => {
+    expect(error).toBeCalledWith(
+      new Error('attempting to getMnemonicHdNodeProvider() without having any seed stored')
+    )
+  })
+})

--- a/app/wallet/index.ts
+++ b/app/wallet/index.ts
@@ -27,10 +27,18 @@ async function newWallet (): Promise<Wallet> {
   return new JellyfishWallet(nodeProvider, accountProvider)
 }
 
+/**
+ * @return WhaleWalletAccount the default index 0 account
+ * @see useCachedWallet to load wallet first
+ */
 export function getAccount (): WhaleWalletAccount {
   return getWallet().get(0)
 }
 
+/**
+ * @return {JellyfishWallet<WhaleWalletAccount, WalletHdNode>}
+ * @see useCachedWallet to load wallet first
+ */
 export function getWallet (): Wallet {
   if (INSTANCE !== undefined) {
     return INSTANCE

--- a/app/wallet/index.ts
+++ b/app/wallet/index.ts
@@ -28,14 +28,6 @@ async function newWallet (): Promise<Wallet> {
 }
 
 /**
- * @return WhaleWalletAccount the default index 0 account
- * @see useCachedWallet to load wallet first
- */
-export function getAccount (): WhaleWalletAccount {
-  return getWallet().get(0)
-}
-
-/**
  * @return {JellyfishWallet<WhaleWalletAccount, WalletHdNode>}
  * @see useCachedWallet to load wallet first
  */

--- a/app/wallet/index.ts
+++ b/app/wallet/index.ts
@@ -1,0 +1,40 @@
+import { JellyfishWallet, WalletHdNode } from '@defichain/jellyfish-wallet'
+import { WhaleWalletAccount } from '@defichain/whale-api-wallet'
+import { useEffect, useState } from 'react'
+import { Logging } from '../logging'
+import { getMnemonicHdNodeProvider } from './mnemonic'
+import { getWhaleWalletAccountProvider } from './whale'
+
+type Wallet = JellyfishWallet<WhaleWalletAccount, WalletHdNode>
+let INSTANCE: Wallet
+
+export function useCachedWallet (): boolean {
+  const [isLoaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    newWallet().then((client) => {
+      INSTANCE = client
+      setLoaded(true)
+    }).catch(Logging.error)
+  }, [])
+
+  return isLoaded
+}
+
+async function newWallet (): Promise<Wallet> {
+  const nodeProvider = await getMnemonicHdNodeProvider()
+  const accountProvider = await getWhaleWalletAccountProvider()
+  return new JellyfishWallet(nodeProvider, accountProvider)
+}
+
+export function getAccount (): WhaleWalletAccount {
+  return getWallet().get(0)
+}
+
+export function getWallet (): Wallet {
+  if (INSTANCE !== undefined) {
+    return INSTANCE
+  }
+
+  throw new Error('useCachedWallet() === true, hooks must be called before getWallet()')
+}

--- a/app/wallet/mnemonic.test.ts
+++ b/app/wallet/mnemonic.test.ts
@@ -1,0 +1,97 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { EnvironmentNetwork } from "../environment";
+import {
+  clearMnemonicHdNodeProvider,
+  getMnemonicHdNodeProvider,
+  hasMnemonicHdNodeProvider,
+  setMnemonicHdNodeProvider
+} from "./mnemonic";
+
+const getItem = jest.spyOn(AsyncStorage, 'getItem')
+const setItem = jest.spyOn(AsyncStorage, 'setItem')
+const removeItem = jest.spyOn(AsyncStorage, 'removeItem')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('getMnemonicHdNodeProvider', () => {
+  it('should get provider (abandon x23)', async () => {
+    getItem
+      .mockResolvedValueOnce(EnvironmentNetwork.LocalPlayground)
+      .mockResolvedValueOnce('408b285c123836004f4b8842c89324c1f01382450c0d439af345ba7fc49acf705489c6fc77dbd4e3dc1dd8cc6bc9f043db8ada1e243c4a0eafb290d399480840')
+
+    const provider = await getMnemonicHdNodeProvider()
+    expect(provider).toBeTruthy()
+
+    const node = provider.derive('0')
+    const pubKey = await node.publicKey()
+    const privKey = await node.privateKey()
+
+    expect(pubKey.toString('hex')).toStrictEqual('03f85401f5aa4e9ed831120a22b8835137404755b30c59109c18c706b2549f7951')
+    expect(privKey.toString('hex')).toStrictEqual('da44d2b30836e1ca7c38b2b32fb5f62e07209364248e8a3eb86ffa2aa2ff3af1')
+  })
+
+  it('should fail without having any seed stored', async () => {
+    getItem
+      .mockResolvedValueOnce(EnvironmentNetwork.LocalPlayground)
+      .mockResolvedValueOnce(null)
+
+    await expect(
+      getMnemonicHdNodeProvider()
+    ).rejects.toThrow('attempting to getMnemonicHdNodeProvider() without having any seed stored')
+  })
+})
+
+describe('setMnemonicHdNodeProvider', () => {
+  it('should set mnemonic (abandon x23)', async () => {
+    const mnemonic = ['abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'art']
+    await setMnemonicHdNodeProvider(mnemonic)
+
+    expect(setItem).toBeCalledWith(
+      'Development.Remote Playground.MNEMONIC_SEED',
+      '408b285c123836004f4b8842c89324c1f01382450c0d439af345ba7fc49acf705489c6fc77dbd4e3dc1dd8cc6bc9f043db8ada1e243c4a0eafb290d399480840'
+    )
+  })
+
+  it('should set mnemonic (void come effort ...)', async () => {
+    getItem.mockResolvedValueOnce(EnvironmentNetwork.LocalPlayground)
+
+    const mnemonic = 'void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold'.split(' ')
+    await setMnemonicHdNodeProvider(mnemonic)
+
+    expect(setItem).toBeCalledWith(
+      'Development.Local Playground.MNEMONIC_SEED',
+      'b873212f885ccffbf4692afcb84bc2e55886de2dfa07d90f5c3c239abc31c0a6ce047e30fd8bf6a281e71389aa82d73df74c7bbfb3b06b4639a5cee775cccd3c'
+    )
+  })
+})
+
+describe('hasMnemonicHdNodeProvider', () => {
+  it('should have mnemonic stored', async () => {
+    getItem
+      .mockResolvedValueOnce(EnvironmentNetwork.RemotePlayground)
+      .mockResolvedValueOnce('0000000000000000000000000000000000000000000000000000000000000000')
+
+    expect(await hasMnemonicHdNodeProvider()).toBeTruthy()
+    expect(getItem).toBeCalledTimes(2)
+  })
+
+  it('should not have mnemonic stored', async () => {
+    getItem.mockResolvedValueOnce(EnvironmentNetwork.RemotePlayground)
+
+
+    expect(await hasMnemonicHdNodeProvider()).toBeFalsy()
+    expect(getItem).toBeCalledTimes(2)
+  })
+})
+
+describe('clearMnemonicHdNodeProvider', () => {
+  it('should removeItem by clearing', async () => {
+    await clearMnemonicHdNodeProvider()
+
+    expect(removeItem).toBeCalledWith(
+      'Development.Remote Playground.MNEMONIC_SEED'
+    )
+  })
+})

--- a/app/wallet/mnemonic.ts
+++ b/app/wallet/mnemonic.ts
@@ -1,0 +1,44 @@
+import { MnemonicHdNodeProvider, mnemonicToSeed } from '@defichain/jellyfish-wallet-mnemonic'
+import { getItem, removeItem, setItem } from '../storage'
+import { getNetworkOptions } from './network'
+
+const KEY = 'MNEMONIC_SEED'
+
+async function getSeed (): Promise<Buffer | undefined> {
+  const seed: string | null = await getItem(KEY)
+  if (seed == null) {
+    return undefined
+  }
+
+  return Buffer.from(seed, 'hex')
+}
+
+export async function getMnemonicHdNodeProvider (): Promise<MnemonicHdNodeProvider> {
+  const seed = await getSeed()
+  if (seed === undefined) {
+    throw new Error('attempting to getMnemonicHdNodeProvider() without having any seed stored')
+  }
+
+  const network = await getNetworkOptions()
+  return MnemonicHdNodeProvider.fromSeed(seed, {
+    bip32: {
+      public: network.bip32.publicPrefix,
+      private: network.bip32.privatePrefix
+    },
+    wif: network.wifPrefix
+  })
+}
+
+export async function setMnemonicHdNodeProvider (mnemonic: string[]): Promise<void> {
+  const seed = mnemonicToSeed(mnemonic)
+  const hex = seed.toString('hex')
+  await setItem(KEY, hex)
+}
+
+export async function hasMnemonicHdNodeProvider (): Promise<boolean> {
+  return await getItem(KEY) !== null
+}
+
+export async function clearMnemonicHdNodeProvider (): Promise<void> {
+  await removeItem(KEY)
+}

--- a/app/wallet/network.ts
+++ b/app/wallet/network.ts
@@ -1,0 +1,17 @@
+import { MainNet, Network, RegTest, TestNet } from '@defichain/jellyfish-network'
+import { EnvironmentNetwork } from '../environment'
+import { getNetwork } from '../storage'
+
+export async function getNetworkOptions (): Promise<Network> {
+  const network = await getNetwork()
+
+  switch (network) {
+    case EnvironmentNetwork.MainNet:
+      return MainNet
+    case EnvironmentNetwork.TestNet:
+      return TestNet
+    case EnvironmentNetwork.LocalPlayground:
+    case EnvironmentNetwork.RemotePlayground:
+      return RegTest
+  }
+}

--- a/app/wallet/whale.ts
+++ b/app/wallet/whale.ts
@@ -1,0 +1,9 @@
+import { WhaleWalletAccountProvider } from '@defichain/whale-api-wallet'
+import { getWhaleClient } from '../api/whale'
+import { getNetworkOptions } from './network'
+
+export async function getWhaleWalletAccountProvider (): Promise<WhaleWalletAccountProvider> {
+  const network = await getNetworkOptions()
+  const client = getWhaleClient()
+  return new WhaleWalletAccountProvider(client, network)
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@defichain/jellyfish-api-core": ">=0.21.0",
+    "@defichain/jellyfish-transaction": ">=0.21.0",
     "@defichain/jellyfish-transaction-builder": ">=0.21.0",
     "@defichain/jellyfish-wallet": ">=0.21.0",
     "@defichain/jellyfish-wallet-mnemonic": ">=0.21.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Environment and network independent Wallet.
1. `useCachedWhaleClient()` to load whale client first
2. `useCachedWallet()` to load jellyfish wallet instance
3. `getWallet()` to get HD wallet
4. `getWallet().get(0)` to get default account
5. `getWallet().get(0).withTransactionBuilder()` to build transaction ready for broadcast

This is created to separate UI logic from the wallet to keep the UI state and UI implementation clean.

#### Additional comments:

1. transaction sending after building transaction will be added at the global store, will create another PR for it.
2. wallet state for global refresh (change env/network) will be managed in the global store with a UUID for an automatic wallet refresh, will create another PR for it.
