### PR TITLE
moved expo-cli bumping to `dependabot.yml` for independent update cycle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,25 +8,34 @@ updates:
       - "kind/dependencies"
     ignore:
       - dependency-name: "@defichain/*"
+      - dependency-name: "@expo/*"
       - dependency-name: "@react-native-async-storage/async-storage"
       - dependency-name: "@react-native-masked-view/masked-view"
-      - dependency-name: "@react-navigation/bottom-tabs"
+      - dependency-name: "@react-navigation/*"
+      - dependency-name: "expo"
+      - dependency-name: "expo-*"
       - dependency-name: "react"
       - dependency-name: "react-dom"
       - dependency-name: "react-native"
+      - dependency-name: "react-native-gesture-handler"
       - dependency-name: "react-native-safe-area-context"
       - dependency-name: "react-native-screens"
-      - dependency-name: "react-native-gesture-handler"
       - dependency-name: "react-native-svg"
       - dependency-name: "react-native-web"
-      - dependency-name: "expo"
-      - dependency-name: "@expo/*"
-      - dependency-name: "expo-*"
       - dependency-name: "@babel/core"
       - dependency-name: "@types/react"
       - dependency-name: "@types/react-native"
       - dependency-name: "typescript"
       - dependency-name: "jest-expo"
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    labels:
+      - "kind/dependencies"
+    allow:
+      - dependency-name: "expo-cli"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/expo-dependencies.yml
+++ b/.github/workflows/expo-dependencies.yml
@@ -22,7 +22,6 @@ jobs:
           expo-version: 4.x
 
       - run: expo upgrade
-      - run: npm install expo-cli@latest
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Let `dependabot.yml` manage `expo-cli` upgrade on a daily cycle.