### PR TITLE
refactor global `/store.ts` usage

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -25,6 +25,9 @@ export default function App (): JSX.Element | null {
   const isLoaded: boolean[] = [
     useCachedResources(),
     // find a connected playground at app load
+    // TODO(fuxingloh): feel like we should deprecate to auto resolve to a fixed network
+    //  instead of automated resolution, after setup we switch to one based on the test?
+    //  might be difficult due to ci automation?
     useConnectedPlayground()
   ]
 

--- a/App.tsx
+++ b/App.tsx
@@ -1,8 +1,8 @@
 import * as SplashScreen from 'expo-splash-screen'
 import React from 'react'
-import { Provider as StoreProvider } from 'react-redux'
 import './_shim'
 import { Logging } from './app/api'
+import { DeFiScanProvider } from './app/contexts/DeFiScanContext'
 import { NetworkProvider } from './app/contexts/NetworkContext'
 import { PlaygroundProvider, useConnectedPlayground } from './app/contexts/PlaygroundContext'
 import { WalletPersistenceProvider } from './app/contexts/WalletPersistenceContext'
@@ -10,9 +10,7 @@ import { WhaleProvider } from './app/contexts/WhaleContext'
 import { useCachedResources } from './app/hooks/useCachedResources'
 import ErrorBoundary from './app/screens/ErrorBoundary/ErrorBoundary'
 import { Main } from './app/screens/Main'
-import { store } from './app/store'
 import { initI18n } from './app/translations'
-import { DeFiScanProvider } from './app/contexts/DeFiScanContext'
 
 initI18n()
 
@@ -47,9 +45,7 @@ export default function App (): JSX.Element | null {
           <WhaleProvider>
             <WalletPersistenceProvider>
               <DeFiScanProvider>
-                <StoreProvider store={store}>
-                  <Main />
-                </StoreProvider>
+                <Main />
               </DeFiScanProvider>
             </WalletPersistenceProvider>
           </WhaleProvider>

--- a/app/contexts/WalletContext.tsx
+++ b/app/contexts/WalletContext.tsx
@@ -67,7 +67,7 @@ function MnemonicUnprotectedProvider (props: WalletProviderProps<MnemonicProvide
   const wallet = useMemo(() => {
     const provider = MnemonicUnprotected.initProvider(props.data, network)
     return initWhaleWallet(provider, network, client)
-  }, [])
+  }, [network])
 
   return (
     <WalletContext.Provider value={wallet}>
@@ -88,7 +88,7 @@ function MnemonicEncryptedProvider (props: WalletProviderProps<EncryptedProvider
   const wallet = useMemo(() => {
     const provider = MnemonicEncrypted.initProvider(props.data, network, promptUI)
     return initWhaleWallet(provider, network, client)
-  }, [promptUI])
+  }, [network, promptUI])
 
   const encryptedWalletInterface: EncryptedWalletUIContext = {
     provide: (ewi: EncryptedWalletInterface) => {

--- a/app/screens/PlaygroundNavigator/PlaygroundScreen.tsx
+++ b/app/screens/PlaygroundNavigator/PlaygroundScreen.tsx
@@ -1,8 +1,10 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { ScrollView } from 'react-native'
+import { Provider as StoreProvider } from 'react-redux'
 import { Text, View } from '../../components'
 import { WalletProvider } from '../../contexts/WalletContext'
 import { useWalletPersistenceContext } from '../../contexts/WalletPersistenceContext'
+import { createStore } from '../../store'
 import { tailwind } from '../../tailwind'
 import { PlaygroundConnection } from './sections/PlaygroundConnection'
 import { PlaygroundToken } from './sections/PlaygroundToken'
@@ -34,6 +36,7 @@ export function PlaygroundScreen (): JSX.Element {
 
 function PlaygroundWalletSection (): JSX.Element | null {
   const { wallets } = useWalletPersistenceContext()
+  const store = useMemo(() => createStore(), [wallets[0]])
 
   if (wallets.length === 0) {
     return null
@@ -41,13 +44,15 @@ function PlaygroundWalletSection (): JSX.Element | null {
 
   return (
     <WalletProvider data={wallets[0]}>
-      <View style={tailwind('mt-4 mb-4')}>
-        <PlaygroundUTXO />
-      </View>
+      <StoreProvider store={store}>
+        <View style={tailwind('mt-4 mb-4')}>
+          <PlaygroundUTXO />
+        </View>
 
-      <View style={tailwind('mt-4 mb-4')}>
-        <PlaygroundToken />
-      </View>
+        <View style={tailwind('mt-4 mb-4')}>
+          <PlaygroundToken />
+        </View>
+      </StoreProvider>
     </WalletProvider>
   )
 }

--- a/app/screens/RootNavigator.tsx
+++ b/app/screens/RootNavigator.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useMemo } from 'react'
+import { Provider as StoreProvider } from 'react-redux'
 import { WalletAddressProvider } from '../contexts/WalletAddressContext'
 import { WalletProvider } from '../contexts/WalletContext'
 import { useWalletPersistenceContext } from '../contexts/WalletPersistenceContext'
+import { createStore } from '../store'
 import { AppNavigator } from './AppNavigator/AppNavigator'
 import { TransactionAuthorization } from './TransactionAuthorization'
 import { WalletNavigator } from './WalletNavigator/WalletNavigator'
@@ -11,6 +13,7 @@ import { WalletNavigator } from './WalletNavigator/WalletNavigator'
  */
 export function RootNavigator (): JSX.Element {
   const { wallets } = useWalletPersistenceContext()
+  const store = useMemo(() => createStore(), [wallets[0]])
 
   if (wallets.length === 0) {
     return <WalletNavigator />
@@ -18,10 +21,12 @@ export function RootNavigator (): JSX.Element {
 
   return (
     <WalletProvider data={wallets[0]}>
-      <WalletAddressProvider>
-        <TransactionAuthorization />
-        <AppNavigator />
-      </WalletAddressProvider>
+      <StoreProvider store={store}>
+        <WalletAddressProvider>
+          <TransactionAuthorization />
+          <AppNavigator />
+        </WalletAddressProvider>
+      </StoreProvider>
     </WalletProvider>
   )
 }

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -13,16 +13,18 @@ import { wallet } from './wallet'
  *
  * Non-global state should be managed independently within its own React Component.
  */
-export const store = configureStore({
-  reducer: {
-    block: block.reducer,
-    wallet: wallet.reducer,
-    ocean: ocean.reducer,
-    transactionQueue: transactionQueue.reducer
-  },
-  middleware: [
-    ...getDefaultMiddleware({ serializableCheck: false })
-  ]
-})
+export const createStore =
+  /* eslint-disable @typescript-eslint/explicit-function-return-type */
+  () => configureStore({
+    reducer: {
+      block: block.reducer,
+      wallet: wallet.reducer,
+      ocean: ocean.reducer,
+      transactionQueue: transactionQueue.reducer
+    },
+    middleware: [
+      ...getDefaultMiddleware({ serializableCheck: false })
+    ]
+  })
 
-export type RootState = ReturnType<typeof store.getState>
+export type RootState = ReturnType<ReturnType<typeof createStore>['getState']>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

- Added missing network deps for wallet, not really required use it's reset at WalletPersistence.
- Refactored `StoreProvider` to be memo-ed and nested within `WalletProvider`
