### PR TITLE
refactor out `Abandon23Playground` from wallet_provider

### DIFF
--- a/app/api/wallet/provider/mnemonic_encrypted.ts
+++ b/app/api/wallet/provider/mnemonic_encrypted.ts
@@ -71,11 +71,5 @@ async function toData (mnemonic: string[], network: EnvironmentNetwork, passphra
 
 export const MnemonicEncrypted = {
   initProvider,
-  toData,
-  /**
-   * Convenience Abandon23 Art on Playground Network Data
-   */
-  Abandon23Playground: toData([
-    'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'art'
-  ], EnvironmentNetwork.LocalPlayground, '123456')
+  toData
 }

--- a/app/api/wallet/provider/mnemonic_unprotected.test.ts
+++ b/app/api/wallet/provider/mnemonic_unprotected.test.ts
@@ -34,7 +34,11 @@ describe('getMnemonicHdNodeProvider', () => {
 
 describe('addMnemonicHdNodeProvider', () => {
   it('should set mnemonic (abandon x23)', async () => {
-    expect(MnemonicUnprotected.Abandon23Playground).toStrictEqual({
+    const data = MnemonicUnprotected.toData([
+      'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'art'
+    ], EnvironmentNetwork.LocalPlayground)
+
+    expect(data).toStrictEqual({
       version: "v1",
       type: WalletType.MNEMONIC_UNPROTECTED,
       raw: {

--- a/app/api/wallet/provider/mnemonic_unprotected.ts
+++ b/app/api/wallet/provider/mnemonic_unprotected.ts
@@ -25,11 +25,5 @@ function toData (mnemonic: string[], network: EnvironmentNetwork): WalletPersist
 
 export const MnemonicUnprotected = {
   initProvider,
-  toData,
-  /**
-   * Convenience Abandon23 Art on Playground Network Data
-   */
-  Abandon23Playground: toData([
-    'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'art'
-  ], EnvironmentNetwork.LocalPlayground)
+  toData
 }

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundWallet.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundWallet.tsx
@@ -34,8 +34,24 @@ export function PlaygroundWallet (): JSX.Element | null {
 
       <PlaygroundAction
         testID='playground_wallet_abandon'
-        title='Setup wallet with abandon x23 + art as mnemonic seed'
-        onPress={async () => await setWallet(MnemonicUnprotected.Abandon23Playground)}
+        title='Setup an unprotected wallet with abandon x23 + art as the 24 word'
+        onPress={async () => {
+          const data = await MnemonicUnprotected.toData([
+            'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'art'
+          ], network)
+          await setWallet(data)
+        }}
+      />
+
+      <PlaygroundAction
+        testID='playground_wallet_abandon_encrypted'
+        title='Setup an encrypted wallet with abandon x23 + art as the 24 word with 000000 passcode'
+        onPress={async () => {
+          const data = await MnemonicEncrypted.toData([
+            'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'art'
+          ], network, '000000')
+          await setWallet(data)
+        }}
       />
 
       <PlaygroundAction


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

Just a minor refactor, doesn't really changes anything. Required as network was nested in wallet_provider.
