### PR TITLE
refactor & fixes for `Network` & `Wallet` issues, `DEX` - APR, `Header` - Network

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -173,6 +173,7 @@
       <w>scripthash</w>
       <w>secp</w>
       <w>segwit</w>
+      <w>semibold</w>
       <w>sendrawtransaction</w>
       <w>sendtoaddress</w>
       <w>sendtokenstoaddress</w>

--- a/App.tsx
+++ b/App.tsx
@@ -4,7 +4,7 @@ import './_shim'
 import { Logging } from './app/api'
 import { DeFiScanProvider } from './app/contexts/DeFiScanContext'
 import { NetworkProvider } from './app/contexts/NetworkContext'
-import { PlaygroundProvider, useConnectedPlayground } from './app/contexts/PlaygroundContext'
+import { PlaygroundProvider } from './app/contexts/PlaygroundContext'
 import { WalletPersistenceProvider } from './app/contexts/WalletPersistenceContext'
 import { WalletStoreProvider } from './app/contexts/WalletStoreProvider'
 import { WhaleProvider } from './app/contexts/WhaleContext'
@@ -21,16 +21,9 @@ initI18n()
  * - CachedPlaygroundClient
  */
 export default function App (): JSX.Element | null {
-  const isLoaded: boolean[] = [
-    useCachedResources(),
-    // find a connected playground at app load
-    // TODO(fuxingloh): feel like we should deprecate to auto resolve to a fixed network
-    //  instead of automated resolution, after setup we switch to one based on the test?
-    //  might be difficult due to ci automation?
-    useConnectedPlayground()
-  ]
+  const isLoaded = useCachedResources()
 
-  if (isLoaded.includes(false)) {
+  if (!isLoaded) {
     SplashScreen.preventAutoHideAsync()
       .catch(Logging.error)
     return null

--- a/app/components/HeaderTitle.tsx
+++ b/app/components/HeaderTitle.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react'
+import { View } from 'react-native'
+import { useDispatch, useSelector } from 'react-redux'
+import { Logging } from '../api'
+import { useNetworkContext } from '../contexts/NetworkContext'
+import { useWhaleApiClient } from '../contexts/WhaleContext'
+import { RootState } from '../store'
+import { block } from '../store/block'
+import { tailwind } from '../tailwind'
+import { Text } from './Text'
+
+export function ConnectionStatus (): JSX.Element {
+  const { network } = useNetworkContext()
+  const connected = useSelector((state: RootState) => state.block.connected)
+  const isPolling = useSelector((state: RootState) => state.block.isPolling)
+  const api = useWhaleApiClient()
+
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    let interval: number
+
+    function refresh (): void {
+      dispatch(block.actions.setPolling(true))
+      api.stats.get().then(({ count }) => {
+        dispatch(block.actions.updateBlock({ count: count.blocks }))
+        dispatch(block.actions.setConnected(true))
+      }).catch((err) => {
+        dispatch(block.actions.updateBlock({ count: 0 }))
+        dispatch(block.actions.setConnected(false))
+        Logging.error(err)
+      })
+    }
+
+    if (!isPolling) {
+      refresh()
+      interval = setInterval(refresh, 3000)
+    }
+    return () => {
+      dispatch(block.actions.setPolling(false))
+      if (interval !== undefined) {
+        clearInterval(interval)
+      }
+    }
+  }, [network])
+  return (
+    <View style={tailwind('flex-row items-center')}>
+      <View
+        testID='header_status_indicator'
+        style={tailwind(`h-2 w-2 rounded-full ${connected ? 'bg-green-500' : 'bg-red-500'} mr-2`)}
+      />
+      <Text testID='header_active_network' style={tailwind('text-xs text-gray-500')}>{network}</Text>
+    </View>
+  )
+}
+
+export function HeaderTitle ({ text, testID }: { text: string, testID?: string }): JSX.Element {
+  return (
+    <View style={tailwind('flex-col')}>
+      <Text
+        testID={testID}
+        style={tailwind('font-semibold')}
+      >
+        {
+          text
+        }
+      </Text>
+      <ConnectionStatus />
+    </View>
+  )
+}

--- a/app/components/OceanInterface/OceanInterface.tsx
+++ b/app/components/OceanInterface/OceanInterface.tsx
@@ -144,7 +144,7 @@ export function OceanInterface (): JSX.Element | null {
           fetchTokens(client, address, dispatch)
         }) // remove the job as soon as completion
     }
-  }, [transaction, walletContext])
+  }, [transaction, walletContext, address])
 
   if (tx === undefined) {
     return null

--- a/app/contexts/NetworkContext.tsx
+++ b/app/contexts/NetworkContext.tsx
@@ -7,7 +7,6 @@ interface Network {
   network: EnvironmentNetwork
   networkName: NetworkName
   updateNetwork: (network: EnvironmentNetwork) => Promise<void>
-  reloadNetwork: () => Promise<void>
 }
 
 const NetworkContext = createContext<Network>(undefined as any)
@@ -47,9 +46,6 @@ export function NetworkProvider (props: React.PropsWithChildren<any>): JSX.Eleme
     async updateNetwork (value: EnvironmentNetwork): Promise<void> {
       await StorageAPI.setNetwork(value)
       setNetwork(value)
-    },
-    async reloadNetwork (): Promise<void> {
-      setNetwork(network)
     }
   }
 

--- a/app/contexts/PlaygroundContext.tsx
+++ b/app/contexts/PlaygroundContext.tsx
@@ -1,7 +1,6 @@
 import { PlaygroundApiClient, PlaygroundRpcClient } from '@defichain/playground-api-client'
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
-import { Logging, StorageAPI } from '../api'
-import { EnvironmentNetwork, getEnvironment, isPlayground } from '../environment'
+import React, { createContext, useContext, useMemo } from 'react'
+import { EnvironmentNetwork, isPlayground } from '../environment'
 import { useNetworkContext } from './NetworkContext'
 
 interface Playground {

--- a/app/contexts/PlaygroundContext.tsx
+++ b/app/contexts/PlaygroundContext.tsx
@@ -17,7 +17,7 @@ export function usePlaygroundContext (): Playground {
     return context
   }
 
-  throw new Error('attempting to usePlaygroundContext without useConnectedPlayground()')
+  throw new Error('Playground not configured')
 }
 
 export function PlaygroundProvider (props: React.PropsWithChildren<any>): JSX.Element | null {
@@ -38,39 +38,6 @@ export function PlaygroundProvider (props: React.PropsWithChildren<any>): JSX.El
       {props.children}
     </PlaygroundContext.Provider>
   )
-}
-
-/**
- * hooks to find connected playground if available
- * @return boolean when completed or found connected playground
- */
-export function useConnectedPlayground (): boolean {
-  const environment = getEnvironment()
-  const [isLoaded, setLoaded] = useState(false)
-
-  useEffect(() => {
-    async function findPlayground (): Promise<void> {
-      for (const network of environment.networks.filter(isPlayground)) {
-        if (await isConnected(network)) {
-          await StorageAPI.setNetwork(network)
-          break
-        }
-      }
-
-      setLoaded(true)
-    }
-
-    findPlayground().catch(Logging.error)
-  }, [])
-
-  return isLoaded
-}
-
-async function isConnected (network: EnvironmentNetwork): Promise<boolean> {
-  const client = newPlaygroundClient(network)
-  return await client.playground.info()
-    .then(() => true)
-    .catch(() => false)
 }
 
 function newPlaygroundClient (network: EnvironmentNetwork): PlaygroundApiClient {

--- a/app/contexts/WalletAddressContext.tsx
+++ b/app/contexts/WalletAddressContext.tsx
@@ -20,7 +20,7 @@ export function WalletAddressProvider (props: React.PropsWithChildren<any>): JSX
     wallet.get(0).getAddress().then(value => {
       setAddress(value)
     }).catch(Logging.error)
-  }, [])
+  }, [wallet])
 
   if (address === undefined) {
     return null

--- a/app/contexts/WalletContext.tsx
+++ b/app/contexts/WalletContext.tsx
@@ -67,7 +67,7 @@ function MnemonicUnprotectedProvider (props: WalletProviderProps<MnemonicProvide
   const wallet = useMemo(() => {
     const provider = MnemonicUnprotected.initProvider(props.data, network)
     return initWhaleWallet(provider, network, client)
-  }, [network, client])
+  }, [network, client, props.data])
 
   return (
     <WalletContext.Provider value={wallet}>
@@ -88,7 +88,7 @@ function MnemonicEncryptedProvider (props: WalletProviderProps<EncryptedProvider
   const wallet = useMemo(() => {
     const provider = MnemonicEncrypted.initProvider(props.data, network, promptUI)
     return initWhaleWallet(provider, network, client)
-  }, [network, client, promptUI])
+  }, [network, client, promptUI, props.data])
 
   const encryptedWalletInterface: EncryptedWalletUIContext = {
     provide: (ewi: EncryptedWalletInterface) => {

--- a/app/contexts/WalletContext.tsx
+++ b/app/contexts/WalletContext.tsx
@@ -67,7 +67,7 @@ function MnemonicUnprotectedProvider (props: WalletProviderProps<MnemonicProvide
   const wallet = useMemo(() => {
     const provider = MnemonicUnprotected.initProvider(props.data, network)
     return initWhaleWallet(provider, network, client)
-  }, [network])
+  }, [network, client])
 
   return (
     <WalletContext.Provider value={wallet}>
@@ -88,7 +88,7 @@ function MnemonicEncryptedProvider (props: WalletProviderProps<EncryptedProvider
   const wallet = useMemo(() => {
     const provider = MnemonicEncrypted.initProvider(props.data, network, promptUI)
     return initWhaleWallet(provider, network, client)
-  }, [network, promptUI])
+  }, [network, client, promptUI])
 
   const encryptedWalletInterface: EncryptedWalletUIContext = {
     provide: (ewi: EncryptedWalletInterface) => {

--- a/app/contexts/WalletStoreProvider.tsx
+++ b/app/contexts/WalletStoreProvider.tsx
@@ -1,19 +1,17 @@
 import React, { PropsWithChildren, useMemo } from 'react'
 import { Provider as StoreProvider } from 'react-redux'
 import { createStore } from '../store'
-import { useNetworkContext } from './NetworkContext'
 import { useWalletPersistenceContext } from './WalletPersistenceContext'
 
 /**
  * Store that is memoized to network & wallets setting.
  */
 export function WalletStoreProvider (props: PropsWithChildren<any>): JSX.Element {
-  const { network } = useNetworkContext()
   const { wallets } = useWalletPersistenceContext()
 
   const store = useMemo(() => {
     return createStore()
-  }, [network, wallets])
+  }, [wallets])
 
   return (
     <StoreProvider store={store}>

--- a/app/hooks/wallet/TokensAPI.ts
+++ b/app/hooks/wallet/TokensAPI.ts
@@ -31,6 +31,6 @@ export function useTokensAPI (): WalletToken[] {
 
   useEffect(() => {
     fetchTokens(client, address, dispatch)
-  }, [address, dispatch])
+  }, [address])
   return tokens
 }

--- a/app/hooks/wallet/TokensAPI.ts
+++ b/app/hooks/wallet/TokensAPI.ts
@@ -31,6 +31,6 @@ export function useTokensAPI (): WalletToken[] {
 
   useEffect(() => {
     fetchTokens(client, address, dispatch)
-  }, [])
+  }, [address])
   return tokens
 }

--- a/app/hooks/wallet/TokensAPI.ts
+++ b/app/hooks/wallet/TokensAPI.ts
@@ -31,6 +31,6 @@ export function useTokensAPI (): WalletToken[] {
 
   useEffect(() => {
     fetchTokens(client, address, dispatch)
-  }, [address])
+  }, [address, dispatch])
   return tokens
 }

--- a/app/screens/AppNavigator/screens/Balances/BalancesNavigator.tsx
+++ b/app/screens/AppNavigator/screens/Balances/BalancesNavigator.tsx
@@ -1,8 +1,9 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import * as React from 'react'
 import { View } from 'react-native'
-import { HeaderFont, Text } from '../../../../components'
+import { Text } from '../../../../components'
 import { BarCodeScanner } from '../../../../components/BarCodeScanner'
+import { ConnectionStatus, HeaderTitle } from '../../../../components/HeaderTitle'
 import { getTokenIcon } from '../../../../components/icons/tokens/_index'
 import { WalletToken } from '../../../../store/wallet'
 import { tailwind } from '../../../../tailwind'
@@ -30,12 +31,12 @@ const BalanceStack = createStackNavigator<BalanceParamList>()
 
 export function BalancesNavigator (): JSX.Element {
   return (
-    <BalanceStack.Navigator screenOptions={{ headerTitleStyle: HeaderFont }}>
+    <BalanceStack.Navigator>
       <BalanceStack.Screen
         name='Balances'
         component={BalancesScreen}
         options={{
-          headerTitle: translate('screens/BalancesScreen', 'Balances'),
+          headerTitle: () => <HeaderTitle text={translate('screens/BalancesScreen', 'Balances')} />,
           headerBackTitleVisible: false
         }}
       />
@@ -43,7 +44,7 @@ export function BalancesNavigator (): JSX.Element {
         name='Receive'
         component={ReceiveScreen}
         options={{
-          headerTitle: translate('screens/ReceiveScreen', 'Receive'),
+          headerTitle: () => <HeaderTitle text={translate('screens/ReceiveScreen', 'Receive')} />,
           headerBackTitleVisible: false
         }}
       />
@@ -51,7 +52,7 @@ export function BalancesNavigator (): JSX.Element {
         name='Send'
         component={SendScreen}
         options={{
-          headerTitle: translate('screens/SendScreen', 'Send'),
+          headerTitle: () => <HeaderTitle text={translate('screens/SendScreen', 'Send')} />,
           headerBackTitleVisible: false
         }}
       />
@@ -66,7 +67,10 @@ export function BalancesNavigator (): JSX.Element {
             return (
               <View style={tailwind('flex-row items-center')}>
                 <Icon />
-                <Text style={tailwind('ml-2 font-semibold')}>{token.displaySymbol}</Text>
+                <View style={tailwind('flex-col ml-2')}>
+                  <Text style={tailwind('font-semibold')}>{token.displaySymbol}</Text>
+                  <ConnectionStatus />
+                </View>
               </View>
             )
           }
@@ -76,7 +80,7 @@ export function BalancesNavigator (): JSX.Element {
         name='Convert'
         component={ConvertScreen}
         options={{
-          headerTitle: translate('screens/ConvertScreen', 'Convert DFI'),
+          headerTitle: () => <HeaderTitle text={translate('screens/ConvertScreen', 'Convert DFI')} />,
           headerBackTitleVisible: false
         }}
       />
@@ -84,7 +88,7 @@ export function BalancesNavigator (): JSX.Element {
         name='BarCodeScanner'
         component={BarCodeScanner}
         options={{
-          headerTitle: translate('screens/ConvertScreen', 'Scan recipient QR'),
+          headerTitle: () => <HeaderTitle text={translate('screens/ConvertScreen', 'Scan recipient QR')} />,
           headerBackTitleVisible: false
         }}
       />
@@ -92,7 +96,7 @@ export function BalancesNavigator (): JSX.Element {
         name='TokensVsUtxo'
         component={TokensVsUtxoScreen}
         options={{
-          headerTitle: translate('screens/ConvertScreen', 'Tokens vs UTXO'),
+          headerTitle: () => <HeaderTitle text={translate('screens/ConvertScreen', 'Tokens vs UTXO')} />,
           headerBackTitleVisible: false
         }}
       />

--- a/app/screens/AppNavigator/screens/Balances/BalancesScreen.tsx
+++ b/app/screens/AppNavigator/screens/Balances/BalancesScreen.tsx
@@ -35,7 +35,7 @@ export function BalancesScreen ({ navigation }: Props): JSX.Element {
     setRefreshing(true)
     await fetchTokens(client, address, dispatch)
     setRefreshing(false)
-  }, [])
+  }, [address])
 
   const tokens = useTokensAPI()
   return (

--- a/app/screens/AppNavigator/screens/Balances/screens/SendScreen.tsx
+++ b/app/screens/AppNavigator/screens/Balances/screens/SendScreen.tsx
@@ -83,7 +83,9 @@ export function SendScreen ({ route, navigation }: Props): JSX.Element {
   const hasPendingJob = useSelector((state: RootState) => hasTxQueued(state.transactionQueue))
 
   useEffect(() => {
-    client.fee.estimate().then((f) => setFee(new BigNumber(f))).catch((e) => Logging.error(e))
+    client.fee.estimate()
+      .then((f) => setFee(new BigNumber(f)))
+      .catch(Logging.error)
   }, [])
 
   useEffect(() => {

--- a/app/screens/AppNavigator/screens/Dex/DexNavigator.tsx
+++ b/app/screens/AppNavigator/screens/Dex/DexNavigator.tsx
@@ -1,7 +1,8 @@
 import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { createStackNavigator } from '@react-navigation/stack'
 import * as React from 'react'
-import { HeaderFont } from '../../../../components/Text'
+import { HeaderFont } from '../../../../components'
+import { HeaderTitle } from '../../../../components/HeaderTitle'
 import { translate } from '../../../../translations'
 import { AddLiquidityScreen } from './DexAddLiquidity'
 import { AddLiquiditySummary, ConfirmAddLiquidityScreen } from './DexConfirmAddLiquidity'
@@ -26,28 +27,28 @@ export function DexNavigator (): JSX.Element {
       <DexStack.Screen
         name='DexScreen'
         component={DexScreen}
-        options={{ headerTitle: translate('screens/DexScreen', 'Decentralized Exchange') }}
+        options={{ headerTitle: () => <HeaderTitle text={translate('screens/DexScreen', 'Decentralized Exchange')} /> }}
       />
       <DexStack.Screen
         name='AddLiquidity'
         component={AddLiquidityScreen}
-        options={{ headerTitle: translate('screens/DexScreen', 'Add Liquidity') }}
+        options={{ headerTitle: () => <HeaderTitle text={translate('screens/DexScreen', 'Add Liquidity')} /> }}
       />
       <DexStack.Screen
         name='ConfirmAddLiquidity'
         component={ConfirmAddLiquidityScreen}
-        options={{ headerTitle: translate('screens/DexScreen', 'Add Liquidity') }}
+        options={{ headerTitle: () => <HeaderTitle text={translate('screens/DexScreen', 'Add Liquidity')} /> }}
       />
       <DexStack.Screen
         name='RemoveLiquidity'
         component={RemoveLiquidityScreen}
-        options={{ headerTitle: translate('screens/DexScreen', 'Remove Liquidity') }}
+        options={{ headerTitle: () => <HeaderTitle text={translate('screens/DexScreen', 'Remove Liquidity')} /> }}
       />
       <DexStack.Screen
         name='PoolSwap'
         component={PoolSwapScreen}
         options={{
-          headerTitle: translate('screens/DexScreen', 'Decentralized Exchange'),
+          headerTitle: () => <HeaderTitle text={translate('screens/DexScreen', 'Decentralized Exchange')} />,
           headerBackTitleVisible: false
         }}
       />

--- a/app/screens/AppNavigator/screens/Dex/DexScreen.tsx
+++ b/app/screens/AppNavigator/screens/Dex/DexScreen.tsx
@@ -41,7 +41,7 @@ export function DexScreen (): JSX.Element {
     }).catch((err) => {
       Logging.error(err)
     })
-  }, [JSON.stringify(tokens)])
+  }, [JSON.stringify(tokens), address])
 
   const onAdd = (data: PoolPairData): void => {
     navigation.navigate('AddLiquidity', { pair: data })
@@ -135,7 +135,7 @@ function PoolPairRowYour (data: AddressToken, onAdd: () => void, onRemove: () =>
       </View>
 
       <View style={tailwind('mt-4')}>
-        <PoolPairInfoLine symbol={data.symbol} reserve={data.amount} />
+        <PoolPairInfoLine symbol={data.symbol} reserve={data.amount} row='your' />
       </View>
     </View>
   )
@@ -162,8 +162,8 @@ function PoolPairRowAvailable (data: PoolPairData, onAdd: () => void, onSwap: ()
       </View>
 
       <View style={tailwind('mt-4')}>
-        <PoolPairInfoLine symbol={symbolA} reserve={data.tokenA.reserve} />
-        <PoolPairInfoLine symbol={symbolB} reserve={data.tokenB.reserve} />
+        <PoolPairInfoLine symbol={symbolA} reserve={data.tokenA.reserve} row='available' />
+        <PoolPairInfoLine symbol={symbolB} reserve={data.tokenB.reserve} row='available' />
       </View>
     </View>
   )
@@ -181,7 +181,7 @@ function PoolPairLiqBtn (props: { name: React.ComponentProps<typeof MaterialIcon
   )
 }
 
-function PoolPairInfoLine (props: { symbol: string, reserve: string }): JSX.Element {
+function PoolPairInfoLine (props: { symbol: string, reserve: string, row: string }): JSX.Element {
   return (
     <View style={tailwind('flex-row justify-between')}>
       <Text style={tailwind('text-sm font-semibold mb-1')}>Pooled {props.symbol}</Text>
@@ -189,7 +189,7 @@ function PoolPairInfoLine (props: { symbol: string, reserve: string }): JSX.Elem
         suffix={` ${props.symbol}`}
         value={props.reserve} decimalScale={2} thousandSeparator displayType='text'
         renderText={value => {
-          return <Text style={tailwind('text-sm font-semibold')}>{value}</Text>
+          return <Text testID={`${props.row}_${props.symbol}`} style={tailwind('text-sm font-semibold')}>{value}</Text>
         }}
       />
     </View>

--- a/app/screens/AppNavigator/screens/Dex/DexScreen.tsx
+++ b/app/screens/AppNavigator/screens/Dex/DexScreen.tsx
@@ -2,6 +2,7 @@ import { AddressToken } from '@defichain/whale-api-client/dist/api/address'
 import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { MaterialIcons } from '@expo/vector-icons'
 import { NavigationProp, useNavigation } from '@react-navigation/native'
+import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import { useEffect, useState } from 'react'
 import { SectionList, TouchableOpacity } from 'react-native'
@@ -162,6 +163,10 @@ function PoolPairRowAvailable (data: PoolPairData, onAdd: () => void, onSwap: ()
       </View>
 
       <View style={tailwind('mt-4')}>
+        {
+          data.apr?.total !== undefined &&
+            <PoolPairAPR symbol={`${symbolA}_${symbolB}`} apr={data.apr.total} row='apr' />
+        }
         <PoolPairInfoLine symbol={symbolA} reserve={data.tokenA.reserve} row='available' />
         <PoolPairInfoLine symbol={symbolB} reserve={data.tokenB.reserve} row='available' />
       </View>
@@ -190,6 +195,22 @@ function PoolPairInfoLine (props: { symbol: string, reserve: string, row: string
         value={props.reserve} decimalScale={2} thousandSeparator displayType='text'
         renderText={value => {
           return <Text testID={`${props.row}_${props.symbol}`} style={tailwind('text-sm font-semibold')}>{value}</Text>
+        }}
+      />
+    </View>
+  )
+}
+
+function PoolPairAPR (props: { symbol: string, apr: number, row: string }): JSX.Element {
+  return (
+    <View style={tailwind('flex-row justify-between items-end')}>
+      <Text style={tailwind('text-sm font-semibold mb-1')}>{translate('screens/DexScreen', 'APR')}</Text>
+      <NumberFormat
+        suffix='%'
+        value={new BigNumber(isNaN(props.apr) ? 0 : props.apr).times(100).toFixed(2)} decimalScale={2} thousandSeparator
+        displayType='text'
+        renderText={value => {
+          return <Text testID={`${props.row}_${props.symbol}`} style={tailwind('text-xl font-semibold')}>{value}</Text>
         }}
       />
     </View>

--- a/app/screens/AppNavigator/screens/Settings/SettingsNavigator.tsx
+++ b/app/screens/AppNavigator/screens/Settings/SettingsNavigator.tsx
@@ -4,6 +4,7 @@ import { createStackNavigator } from '@react-navigation/stack'
 import * as React from 'react'
 import { TouchableOpacity } from 'react-native'
 import { HeaderFont } from '../../../../components'
+import { HeaderTitle } from '../../../../components/HeaderTitle'
 import { tailwind } from '../../../../tailwind'
 import { translate } from '../../../../translations'
 import { AboutScreen } from './screens/AboutScreen'
@@ -30,7 +31,7 @@ export function SettingsNavigator (): JSX.Element {
         name='SettingsScreen'
         component={SettingsScreen}
         options={{
-          headerTitle: translate('screens/SettingsNavigator', 'Settings'),
+          headerTitle: () => <HeaderTitle text={translate('screens/SettingsNavigator', 'Settings')} />,
           headerRightContainerStyle: tailwind('px-2 py-2'),
           headerRight: (): JSX.Element => (
             <TouchableOpacity
@@ -46,7 +47,7 @@ export function SettingsNavigator (): JSX.Element {
         name='CommunityScreen'
         component={CommunityScreen}
         options={{
-          headerTitle: translate('screens/CommunityScreen', 'Community'),
+          headerTitle: () => <HeaderTitle text={translate('screens/CommunityScreen', 'Community')} />,
           headerBackTitleVisible: false
         }}
       />
@@ -54,7 +55,7 @@ export function SettingsNavigator (): JSX.Element {
         name='RecoveryWordsScreen'
         component={RecoveryWordsScreen}
         options={{
-          headerTitle: translate('screens/Settings', 'Recovery Words'),
+          headerTitle: () => <HeaderTitle text={translate('screens/Settings', 'Recovery Words')} />,
           headerBackTitleVisible: false
         }}
       />
@@ -62,7 +63,7 @@ export function SettingsNavigator (): JSX.Element {
         name='AboutScreen'
         component={AboutScreen}
         options={{
-          headerTitle: translate('screens/AboutScreen', 'About'),
+          headerTitle: () => <HeaderTitle text={translate('screens/AboutScreen', 'About')} />,
           headerBackTitleVisible: false
         }}
       />

--- a/app/screens/AppNavigator/screens/Transactions/TransactionsNavigator.tsx
+++ b/app/screens/AppNavigator/screens/Transactions/TransactionsNavigator.tsx
@@ -1,6 +1,7 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import * as React from 'react'
-import { HeaderFont } from '../../../../components/Text'
+import { HeaderFont } from '../../../../components'
+import { HeaderTitle } from '../../../../components/HeaderTitle'
 import { translate } from '../../../../translations'
 import { VMTransaction } from './screens/stateProcessor'
 import { TransactionDetailScreen } from './screens/TransactionDetailScreen'
@@ -27,14 +28,14 @@ export function TransactionsNavigator (): JSX.Element {
         name='Transactions'
         component={TransactionsScreen}
         options={{
-          headerTitle: translate('screens/TransactionsScreen', 'Transactions')
+          headerTitle: () => <HeaderTitle text={translate('screens/TransactionsScreen', 'Transactions')} />
         }}
       />
       <TransactionsStack.Screen
         name='TransactionDetail'
         component={TransactionDetailScreen}
         options={{
-          headerTitle: translate('screens/TransactionsDetailScreen', 'Transaction'),
+          headerTitle: () => <HeaderTitle text={translate('screens/TransactionsDetailScreen', 'Transaction')} />,
           headerBackTitleVisible: false
         }}
       />

--- a/app/screens/AppNavigator/screens/Transactions/TransactionsScreen.tsx
+++ b/app/screens/AppNavigator/screens/Transactions/TransactionsScreen.tsx
@@ -53,7 +53,9 @@ export function TransactionsScreen (): JSX.Element {
     loadData(nextToken)
   }
 
-  useEffect(() => loadData(), [])
+  useEffect(() => {
+    loadData()
+  }, [address])
 
   return activities.length === 0
     ? <EmptyTransaction navigation={navigation} handleRefresh={loadData} loadingStatus={loadingStatus} />

--- a/app/screens/Main.web.tsx
+++ b/app/screens/Main.web.tsx
@@ -1,30 +1,21 @@
 import { NavigationContainer } from '@react-navigation/native'
 import React from 'react'
 import { StyleSheet, View } from 'react-native'
-import { useNetworkContext } from '../contexts/NetworkContext'
-import { isPlayground } from '../environment'
 import { tailwind } from '../tailwind'
 import { PlaygroundNavigator } from './PlaygroundNavigator/PlaygroundNavigator'
 import { RootNavigator } from './RootNavigator'
 
 export function Main (): JSX.Element {
-  const { network } = useNetworkContext()
-  const playground = isPlayground(network)
-
   return (
     <View style={tailwind('flex-row flex-1 justify-center items-center bg-black')}>
       <View style={styles.phone}>
         <RootNavigator />
       </View>
-      {
-        playground ? (
-          <View style={[styles.phone, tailwind('bg-white ml-2')]}>
-            <NavigationContainer>
-              <PlaygroundNavigator />
-            </NavigationContainer>
-          </View>
-        ) : null
-      }
+      <View style={[styles.phone, tailwind('bg-white ml-2')]}>
+        <NavigationContainer>
+          <PlaygroundNavigator />
+        </NavigationContainer>
+      </View>
     </View>
   )
 }

--- a/app/screens/PlaygroundNavigator/PlaygroundNavigator.tsx
+++ b/app/screens/PlaygroundNavigator/PlaygroundNavigator.tsx
@@ -1,6 +1,7 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React from 'react'
 import { HeaderFont } from '../../components'
+import { HeaderTitle } from '../../components/HeaderTitle'
 import { PlaygroundScreen } from './PlaygroundScreen'
 
 export interface PlaygroundParamList {
@@ -18,7 +19,7 @@ export function PlaygroundNavigator (): JSX.Element {
         name='PlaygroundScreen'
         component={PlaygroundScreen}
         options={{
-          headerTitle: 'DeFi Testing',
+          headerTitle: () => <HeaderTitle text='DeFi Testing' />,
           headerBackTitleVisible: false
         }}
       />

--- a/app/screens/PlaygroundNavigator/PlaygroundNavigator.tsx
+++ b/app/screens/PlaygroundNavigator/PlaygroundNavigator.tsx
@@ -18,7 +18,7 @@ export function PlaygroundNavigator (): JSX.Element {
         name='PlaygroundScreen'
         component={PlaygroundScreen}
         options={{
-          headerTitle: 'DeFi Playground',
+          headerTitle: 'DeFi Testing',
           headerBackTitleVisible: false
         }}
       />

--- a/app/screens/PlaygroundNavigator/PlaygroundScreen.tsx
+++ b/app/screens/PlaygroundNavigator/PlaygroundScreen.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { ScrollView } from 'react-native'
-import { Text, View } from '../../components'
+import { useNetworkContext } from '../../contexts/NetworkContext'
 import { WalletProvider } from '../../contexts/WalletContext'
 import { useWalletPersistenceContext } from '../../contexts/WalletPersistenceContext'
+import { isPlayground } from '../../environment'
 import { tailwind } from '../../tailwind'
 import { PlaygroundConnection } from './sections/PlaygroundConnection'
 import { PlaygroundToken } from './sections/PlaygroundToken'
@@ -11,22 +12,9 @@ import { PlaygroundWallet } from './sections/PlaygroundWallet'
 
 export function PlaygroundScreen (): JSX.Element {
   return (
-    <ScrollView style={tailwind('p-4 bg-white')} contentInsetAdjustmentBehavior='always'>
-      <View style={tailwind('mb-4 p-3 bg-pink-100 rounded')}>
-        <Text style={tailwind('text-xs font-medium')}>
-          DeFi Playground is a specialized testing blockchain isolated from MainNet for testing DeFi applications.
-          Assets are not real, it can be minted by anyone. Blocks are generated every 3 seconds, the chain resets daily.
-        </Text>
-      </View>
-
-      <View style={tailwind('mt-4 mb-4')}>
-        <PlaygroundConnection />
-      </View>
-
-      <View style={tailwind('mt-4 mb-4')}>
-        <PlaygroundWallet />
-      </View>
-
+    <ScrollView style={tailwind('pb-16 bg-gray-100')} contentInsetAdjustmentBehavior='always'>
+      <PlaygroundConnection />
+      <PlaygroundWallet />
       <PlaygroundWalletSection />
     </ScrollView>
   )
@@ -38,20 +26,16 @@ export function PlaygroundScreen (): JSX.Element {
  */
 function PlaygroundWalletSection (): JSX.Element | null {
   const { wallets } = useWalletPersistenceContext()
+  const { network } = useNetworkContext()
 
-  if (wallets.length === 0) {
+  if (wallets.length === 0 || !isPlayground(network)) {
     return null
   }
 
   return (
     <WalletProvider data={wallets[0]}>
-      <View style={tailwind('mt-4 mb-4')}>
-        <PlaygroundUTXO />
-      </View>
-
-      <View style={tailwind('mt-4 mb-4')}>
-        <PlaygroundToken />
-      </View>
+      <PlaygroundUTXO />
+      <PlaygroundToken />
     </WalletProvider>
   )
 }

--- a/app/screens/PlaygroundNavigator/components/PlaygroundAction.tsx
+++ b/app/screens/PlaygroundNavigator/components/PlaygroundAction.tsx
@@ -1,26 +1,24 @@
 import { Ionicons } from '@expo/vector-icons'
 import React from 'react'
 import { TouchableOpacity, View } from 'react-native'
-import { Text } from '../../../components/Text'
+import { Text } from '../../../components'
 import { tailwind } from '../../../tailwind'
 
-export function PlaygroundAction (props: {
+interface PlaygroundActionProps {
   testID: string
   title: string
   onPress: () => void
-}): JSX.Element {
+}
+
+export function PlaygroundAction (props: PlaygroundActionProps): JSX.Element {
   return (
-    <TouchableOpacity
-      style={tailwind('flex-row items-center justify-between py-3')}
-      onPress={props.onPress}
-      testID={props.testID}
-    >
-      <Text style={tailwind('flex-1 text-sm font-medium text-gray-900')}>
-        {props.title}
-      </Text>
-      <View style={tailwind('px-4')} />
-      <View>
-        <Ionicons name='chevron-forward' size={24} />
+    <TouchableOpacity onPress={props.onPress} testID={props.testID}>
+      <View style={tailwind('flex-row items-center justify-between p-4 bg-white border-b border-gray-100')}>
+        <Text style={tailwind('flex-1 font-medium ')}>
+          {props.title}
+        </Text>
+        <View style={tailwind('px-4')} />
+        <Ionicons name='chevron-forward' style={tailwind('opacity-70')} size={18} />
       </View>
     </TouchableOpacity>
   )

--- a/app/screens/PlaygroundNavigator/components/PlaygroundStatus.tsx
+++ b/app/screens/PlaygroundNavigator/components/PlaygroundStatus.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 import { View } from 'react-native'
 import { tailwind } from '../../../tailwind'
 
-export function PlaygroundStatus (props: {
+export interface PlaygroundStatusProps {
   loading?: boolean
   online?: boolean
   offline?: boolean
   error?: boolean
-}): JSX.Element {
+}
+
+export function PlaygroundStatus (props: PlaygroundStatusProps): JSX.Element {
   if (props.online !== undefined && props.online) {
     return <View style={tailwind('h-3 w-3 rounded-full bg-green-500')} />
   }

--- a/app/screens/PlaygroundNavigator/components/PlaygroundStatus.tsx
+++ b/app/screens/PlaygroundNavigator/components/PlaygroundStatus.tsx
@@ -11,16 +11,16 @@ export interface PlaygroundStatusProps {
 
 export function PlaygroundStatus (props: PlaygroundStatusProps): JSX.Element {
   if (props.online !== undefined && props.online) {
-    return <View style={tailwind('h-3 w-3 rounded-full bg-green-500')} />
+    return <View testID='playground_status_indicator' style={tailwind('h-3 w-3 rounded-full bg-green-500')} />
   }
   if (props.offline !== undefined && props.offline) {
-    return <View style={tailwind('h-3 w-3 rounded-full bg-red-500')} />
+    return <View testID='playground_status_indicator' style={tailwind('h-3 w-3 rounded-full bg-red-500')} />
   }
   if (props.loading !== undefined && props.loading) {
-    return <View style={tailwind('h-3 w-3 rounded-full bg-blue-500')} />
+    return <View testID='playground_status_indicator' style={tailwind('h-3 w-3 rounded-full bg-blue-500')} />
   }
   if (props.error !== undefined && props.error) {
-    return <View style={tailwind('h-3 w-3 rounded-full bg-yellow-500')} />
+    return <View testID='playground_status_indicator' style={tailwind('h-3 w-3 rounded-full bg-yellow-500')} />
   }
-  return <View style={tailwind('h-3 w-3 rounded-full bg-gray-500')} />
+  return <View testID='playground_status_indicator' style={tailwind('h-3 w-3 rounded-full bg-gray-500')} />
 }

--- a/app/screens/PlaygroundNavigator/components/PlaygroundTitle.tsx
+++ b/app/screens/PlaygroundNavigator/components/PlaygroundTitle.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Text, View } from '../../../components'
+import { tailwind } from '../../../tailwind'
+import { PlaygroundStatus, PlaygroundStatusProps } from './PlaygroundStatus'
+
+interface PlaygroundTitleProps {
+  title: string
+  status: PlaygroundStatusProps
+}
+
+export function PlaygroundTitle (props: PlaygroundTitleProps): JSX.Element {
+  return (
+    <View style={tailwind('px-4 py-1 mb-1 mt-4 flex-row flex items-center')}>
+      <Text style={tailwind('text-lg font-semibold mr-2')}>
+        {props.title}
+      </Text>
+      <PlaygroundStatus {...props.status} />
+    </View>
+  )
+}

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundConnection.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundConnection.tsx
@@ -37,7 +37,7 @@ export function PlaygroundConnection (): JSX.Element {
 
       <View style={tailwind('px-4 py-4 bg-white')}>
         <Text style={tailwind('font-medium')}>
-          Network: {network}
+          Network: <Text testID='playground_active_network'>{network}</Text>
         </Text>
         <Text>
           Blocks: {count === 0 ? '...' : count}

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundConnection.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundConnection.tsx
@@ -1,35 +1,16 @@
-import React, { useEffect, useState } from 'react'
-import { Logging } from '../../../api'
+import React from 'react'
+import { useSelector } from 'react-redux'
 import { Text, View } from '../../../components'
 import { useNetworkContext } from '../../../contexts/NetworkContext'
-import { useWhaleApiClient } from '../../../contexts/WhaleContext'
 import { isPlayground } from '../../../environment'
+import { RootState } from '../../../store'
 import { tailwind } from '../../../tailwind'
 import { PlaygroundTitle } from '../components/PlaygroundTitle'
 
 export function PlaygroundConnection (): JSX.Element {
   const { network } = useNetworkContext()
-  const api = useWhaleApiClient()
-
-  const [count, setCount] = useState(0)
-  const [connected, setConnected] = useState(false)
-
-  useEffect(() => {
-    function refresh (): void {
-      api.stats.get().then(({ count }) => {
-        setCount(count.blocks)
-        setConnected(true)
-      }).catch((err) => {
-        setCount(0)
-        setConnected(false)
-        Logging.error(err)
-      })
-    }
-
-    refresh()
-    const interval = setInterval(refresh, 3000)
-    return () => clearInterval(interval)
-  }, [network])
+  const connected = useSelector((state: RootState) => state.block.connected)
+  const count = useSelector((state: RootState) => state.block.count)
 
   return (
     <View>

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundToken.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundToken.tsx
@@ -1,12 +1,11 @@
 import { TokenInfo } from '@defichain/jellyfish-api-core/dist/category/token'
 import { PlaygroundRpcClient } from '@defichain/playground-api-client'
 import React, { useEffect, useState } from 'react'
-import { Text, View } from '../../../components'
+import { View } from '../../../components'
 import { usePlaygroundContext } from '../../../contexts/PlaygroundContext'
 import { useWallet } from '../../../contexts/WalletContext'
-import { tailwind } from '../../../tailwind'
 import { PlaygroundAction } from '../components/PlaygroundAction'
-import { PlaygroundStatus } from '../components/PlaygroundStatus'
+import { PlaygroundTitle } from '../components/PlaygroundTitle'
 
 export function PlaygroundToken (): JSX.Element | null {
   const wallet = useWallet()
@@ -41,16 +40,14 @@ export function PlaygroundToken (): JSX.Element | null {
 
   return (
     <View>
-      <View style={tailwind('flex-row flex items-center')}>
-        <Text style={tailwind('text-xl font-bold')}>Token</Text>
-        <View style={tailwind('ml-2')}>
-          <PlaygroundStatus
-            online={status === 'online'}
-            loading={status === 'loading'}
-            error={status === 'error'}
-          />
-        </View>
-      </View>
+      <PlaygroundTitle
+        title='Token' status={{
+          online: status === 'online',
+          loading: status === 'loading',
+          error: status === 'error'
+        }}
+      />
+
       <PlaygroundAction
         key='0'
         testID='playground_token_DFI'
@@ -62,6 +59,7 @@ export function PlaygroundToken (): JSX.Element | null {
           })
         }}
       />
+
       {actions}
     </View>
   )

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundToken.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundToken.tsx
@@ -21,7 +21,7 @@ export function PlaygroundToken (): JSX.Element | null {
     }).catch(() => {
       setStatus('error')
     })
-  }, [])
+  }, [wallet])
 
   const actions = tokens.filter(({ symbol }) => symbol !== 'DFI').map(token => {
     return (

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundUTXO.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundUTXO.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { Text, View } from '../../../components'
+import { View } from '../../../components'
 import { usePlaygroundContext } from '../../../contexts/PlaygroundContext'
 import { useWallet } from '../../../contexts/WalletContext'
 import { useWhaleApiClient } from '../../../contexts/WhaleContext'
 import { fetchTokens } from '../../../hooks/wallet/TokensAPI'
-import { tailwind } from '../../../tailwind'
 import { PlaygroundAction } from '../components/PlaygroundAction'
-import { PlaygroundStatus } from '../components/PlaygroundStatus'
+import { PlaygroundTitle } from '../components/PlaygroundTitle'
 
 export function PlaygroundUTXO (): JSX.Element {
   const wallet = useWallet()
@@ -26,16 +25,13 @@ export function PlaygroundUTXO (): JSX.Element {
 
   return (
     <View>
-      <View style={tailwind('flex-row flex items-center')}>
-        <Text style={tailwind('text-xl font-bold')}>UTXO</Text>
-        <View style={tailwind('ml-2')}>
-          <PlaygroundStatus
-            online={status === 'online'}
-            loading={status === 'loading'}
-            error={status === 'error'}
-          />
-        </View>
-      </View>
+      <PlaygroundTitle
+        title='UTXO' status={{
+          online: status === 'online',
+          loading: status === 'loading',
+          error: status === 'error'
+        }}
+      />
 
       {status === 'online' ? (
         <>

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundUTXO.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundUTXO.tsx
@@ -22,7 +22,7 @@ export function PlaygroundUTXO (): JSX.Element {
     }).catch(() => {
       setStatus('error')
     })
-  }, [])
+  }, [wallet])
 
   return (
     <View>

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundWallet.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundWallet.tsx
@@ -11,7 +11,7 @@ import { PlaygroundTitle } from '../components/PlaygroundTitle'
 
 export function PlaygroundWallet (): JSX.Element | null {
   const { wallets, clearWallets, setWallet } = useWalletPersistenceContext()
-  const { network } = useNetworkContext()
+  const { network, updateNetwork } = useNetworkContext()
 
   return (
     <View>
@@ -27,6 +27,7 @@ export function PlaygroundWallet (): JSX.Element | null {
         testID='playground_wallet_abandon'
         title='Setup an unprotected wallet with abandon x23 + art as the 24 word'
         onPress={async () => {
+          await updateNetwork(network)
           const data = await MnemonicUnprotected.toData([
             'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'art'
           ], network)
@@ -38,6 +39,7 @@ export function PlaygroundWallet (): JSX.Element | null {
         testID='playground_wallet_abandon_encrypted'
         title='Setup an encrypted wallet with abandon x23 + art as the 24 word with 000000 passcode'
         onPress={async () => {
+          await updateNetwork(network)
           const data = await MnemonicEncrypted.toData([
             'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'abandon', 'art'
           ], network, '000000')
@@ -49,6 +51,7 @@ export function PlaygroundWallet (): JSX.Element | null {
         testID='playground_wallet_random'
         title='Setup an encrypted wallet with a random seed using 000000 passcode'
         onPress={async () => {
+          await updateNetwork(network)
           const words = generateMnemonicWords(24, (numOfBytes: number) => {
             const bytes = getRandomBytes(numOfBytes)
             return Buffer.from(bytes)

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundWallet.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundWallet.tsx
@@ -3,12 +3,11 @@ import { getRandomBytes } from 'expo-random'
 import React from 'react'
 import { MnemonicEncrypted, MnemonicUnprotected } from '../../../api/wallet'
 import { MnemonicWords } from '../../../api/wallet/mnemonic_words'
-import { Text, View } from '../../../components'
+import { View } from '../../../components'
 import { useNetworkContext } from '../../../contexts/NetworkContext'
 import { useWalletPersistenceContext } from '../../../contexts/WalletPersistenceContext'
-import { tailwind } from '../../../tailwind'
 import { PlaygroundAction } from '../components/PlaygroundAction'
-import { PlaygroundStatus } from '../components/PlaygroundStatus'
+import { PlaygroundTitle } from '../components/PlaygroundTitle'
 
 export function PlaygroundWallet (): JSX.Element | null {
   const { wallets, clearWallets, setWallet } = useWalletPersistenceContext()
@@ -16,15 +15,7 @@ export function PlaygroundWallet (): JSX.Element | null {
 
   return (
     <View>
-      <View style={tailwind('flex-row flex items-center')}>
-        <Text style={tailwind('text-xl font-bold')}>Wallet</Text>
-        <View style={tailwind('ml-2')}>
-          <PlaygroundStatus
-            online={wallets.length > 0}
-            offline={wallets.length === 0}
-          />
-        </View>
-      </View>
+      <PlaygroundTitle title='Wallet' status={{ online: wallets.length > 0, offline: wallets.length === 0 }} />
 
       <PlaygroundAction
         testID='playground_wallet_clear'

--- a/app/screens/TransactionAuthorization.tsx
+++ b/app/screens/TransactionAuthorization.tsx
@@ -273,6 +273,7 @@ async function execWithAutoRetries (promptPromise: () => Promise<any>, onAutoRet
   try {
     return await promptPromise()
   } catch (e) {
+    Logging.error(e)
     if (e.message === 'USER_CANCELED') throw e
     if (++retries < MAX_PASSCODE_ATTEMPT) {
       await onAutoRetry(retries)

--- a/app/screens/WalletNavigator/WalletNavigator.tsx
+++ b/app/screens/WalletNavigator/WalletNavigator.tsx
@@ -1,21 +1,22 @@
+import { EncryptedProviderData } from '@defichain/jellyfish-wallet-encrypted'
 import { LinkingOptions, NavigationContainer, NavigationContainerRef } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
 import * as Linking from 'expo-linking'
 import * as React from 'react'
+import { WalletPersistenceData } from '../../api/wallet'
 import { HeaderFont } from '../../components'
+import { HeaderTitle } from '../../components/HeaderTitle'
 import { DeFiChainTheme } from '../../constants/Theme'
 import { translate } from '../../translations'
 import { CreateMnemonicWallet } from './screens/CreateWallet/CreateMnemonicWallet'
 import { CreateWalletGuidelines } from './screens/CreateWallet/CreateWalletGuidelines'
+import { EnrollBiometric } from './screens/CreateWallet/EnrollBiometric'
 import { GuidelinesRecoveryWords } from './screens/CreateWallet/GuidelinesRecoveryWords'
+import { PinConfirmation } from './screens/CreateWallet/PinConfirmation'
+import { PinCreation } from './screens/CreateWallet/PinCreation'
 import { VerifyMnemonicWallet } from './screens/CreateWallet/VerifyMnemonicWallet'
 import { Onboarding } from './screens/Onboarding'
 import { RestoreMnemonicWallet } from './screens/RestoreWallet/RestoreMnemonicWallet'
-import { PinCreation } from './screens/CreateWallet/PinCreation'
-import { PinConfirmation } from './screens/CreateWallet/PinConfirmation'
-import { EnrollBiometric } from './screens/CreateWallet/EnrollBiometric'
-import { EncryptedProviderData } from '@defichain/jellyfish-wallet-encrypted'
-import { WalletPersistenceData } from '../../api/wallet/persistence'
 
 type PinCreationType = 'create' | 'restore'
 
@@ -80,7 +81,7 @@ export function WalletNavigator (): JSX.Element {
           name='CreateWalletGuidelines'
           component={CreateWalletGuidelines}
           options={{
-            headerTitle: translate('screens/WalletNavigator', 'Guidelines'),
+            headerTitle: () => <HeaderTitle text={translate('screens/WalletNavigator', 'Guidelines')} />,
             headerBackTitleVisible: false
           }}
         />
@@ -88,7 +89,7 @@ export function WalletNavigator (): JSX.Element {
           name='GuidelinesRecoveryWords'
           component={GuidelinesRecoveryWords}
           options={{
-            headerTitle: translate('screens/WalletNavigator', 'Learn More'),
+            headerTitle: () => <HeaderTitle text={translate('screens/WalletNavigator', 'Learn More')} />,
             headerBackTitleVisible: false
           }}
         />
@@ -96,7 +97,7 @@ export function WalletNavigator (): JSX.Element {
           name='CreateMnemonicWallet'
           component={CreateMnemonicWallet}
           options={{
-            headerTitle: translate('screens/WalletNavigator', 'Display recovery words'),
+            headerTitle: () => <HeaderTitle text={translate('screens/WalletNavigator', 'Display recovery words')} />,
             headerBackTitleVisible: false
           }}
         />
@@ -104,7 +105,7 @@ export function WalletNavigator (): JSX.Element {
           name='VerifyMnemonicWallet'
           component={VerifyMnemonicWallet}
           options={{
-            headerTitle: translate('screens/WalletNavigator', 'Verify words'),
+            headerTitle: () => <HeaderTitle text={translate('screens/WalletNavigator', 'Verify words')} />,
             headerBackTitleVisible: false
           }}
         />
@@ -112,7 +113,7 @@ export function WalletNavigator (): JSX.Element {
           name='RestoreMnemonicWallet'
           component={RestoreMnemonicWallet}
           options={{
-            headerTitle: translate('screens/WalletNavigator', 'Restore Wallet'),
+            headerTitle: () => <HeaderTitle text={translate('screens/WalletNavigator', 'Restore Wallet')} />,
             headerBackTitleVisible: false
           }}
         />
@@ -120,7 +121,7 @@ export function WalletNavigator (): JSX.Element {
           name='PinCreation'
           component={PinCreation}
           options={{
-            headerTitle: translate('screens/WalletNavigator', 'Create a passcode'),
+            headerTitle: () => <HeaderTitle text={translate('screens/WalletNavigator', 'Create a passcode')} />,
             headerBackTitleVisible: false
           }}
         />
@@ -128,7 +129,7 @@ export function WalletNavigator (): JSX.Element {
           name='PinConfirmation'
           component={PinConfirmation}
           options={{
-            headerTitle: translate('screens/WalletNavigator', 'Verify passcode'),
+            headerTitle: () => <HeaderTitle text={translate('screens/WalletNavigator', 'Verify passcode')} />,
             headerBackTitleVisible: false
           }}
         />
@@ -136,7 +137,7 @@ export function WalletNavigator (): JSX.Element {
           name='EnrollBiometric'
           component={EnrollBiometric}
           options={{
-            headerTitle: translate('screens/WalletNavigator', 'Wallet Created')
+            headerTitle: () => <HeaderTitle text={translate('screens/WalletNavigator', 'Wallet Created')} />
           }}
         />
       </WalletStack.Navigator>

--- a/app/store/block.test.ts
+++ b/app/store/block.test.ts
@@ -5,19 +5,33 @@ describe('block reducer', () => {
 
   beforeEach(() => {
     initialState = {
-      count: 77
+      count: 77,
+      isPolling: false,
+      connected: false
     };
   })
 
   it('should handle initial state', () => {
     expect(block.reducer(undefined, { type: 'unknown' })).toEqual({
-      count: undefined
+      count: undefined,
+      connected: false,
+      isPolling: false
     });
   });
 
   it('should handle updateBlock', () => {
     const payload = { count: 99 }
     const actual = block.reducer(initialState, block.actions.updateBlock(payload));
-    expect(actual).toStrictEqual(payload)
+    expect(actual).toStrictEqual({ ...payload, isPolling: false, connected: false })
+  });
+
+  it('should handle setConnected', () => {
+    const actual = block.reducer(initialState, block.actions.setConnected(true));
+    expect(actual).toStrictEqual({ count: 77, isPolling: false, connected: true })
+  });
+
+  it('should handle setPolling', () => {
+    const actual = block.reducer(initialState, block.actions.setPolling(true));
+    expect(actual).toStrictEqual({ count: 77, isPolling: true, connected: false })
   });
 })

--- a/app/store/block.ts
+++ b/app/store/block.ts
@@ -2,10 +2,14 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 export interface BlockState {
   count?: number
+  connected: boolean
+  isPolling: boolean
 }
 
 const initialState: BlockState = {
-  count: undefined
+  count: undefined,
+  connected: false,
+  isPolling: false
 }
 
 export const block = createSlice({
@@ -14,6 +18,12 @@ export const block = createSlice({
   reducers: {
     updateBlock: (state, action: PayloadAction<{ count: number }>) => {
       state.count = action.payload.count
+    },
+    setConnected: (state, action: PayloadAction<boolean>) => {
+      state.connected = action.payload
+    },
+    setPolling: (state, action: PayloadAction<boolean>) => {
+      state.isPolling = action.payload
     }
   }
 })

--- a/cypress/integration/functional/onboarding/createMnemonicWallet.spec.ts
+++ b/cypress/integration/functional/onboarding/createMnemonicWallet.spec.ts
@@ -1,38 +1,27 @@
 context('Onboarding - Create Mnemonic Wallet', () => {
-  const numbers = Array.from(Array(24), (v, i) => i + 1)
   const recoveryWords: string[] = []
   const settingsRecoveryWords: string[] = []
 
-  before(function () {
+  beforeEach(() => {
+    cy.restoreLocalStorage()
+  })
+
+  afterEach(() => {
+    cy.saveLocalStorage()
+  })
+
+  it('should start creation of mnemonic wallet', function () {
     cy.visit('/')
     cy.exitWallet()
-    cy.getByTestID('create_wallet_button').click()
-    cy.getByTestID('guidelines_switch').click()
-    cy.getByTestID('create_recovery_words_button').click()
-    cy.url().should('include', 'wallet/mnemonic/create')
+    cy.startCreateMnemonicWallet(recoveryWords)
   })
 
-  numbers.forEach((i) => {
-    it(`should display word #${i}`, function () {
-      cy.getByTestID(`word_${i}`).should('exist')
-      cy.getByTestID(`word_${i}_number`).should('exist').contains(`${i}.`)
-      cy.getByTestID(`word_${i}`).then(($txt: any) => {
-        recoveryWords.push($txt[0].textContent)
-      })
-    })
-  })
-
-  it('should be able to click verify button', function () {
-    cy.getByTestID('verify_button').should('not.have.attr', 'disabled')
-    cy.getByTestID('verify_button').click()
-  })
-
-  it('should have disabled button', function () {
+  it('should have disabled button for verify words', function () {
     cy.getByTestID('verify_words_button').should('have.attr', 'disabled')
   })
 
   it('should select incorrect words', function () {
-    [0, 1, 2, 3, 4, 5].forEach((key, index) => {
+    Array.from(Array(6), (v, i) => i + 1).forEach((key, index) => {
       cy.getByTestID(`line_${index}`).then(($txt: any) => {
         const wordIndex = (+$txt[0].textContent.replace('?', '').replace('#', '')) - 1
         cy.getByTestID(`recovery_word_row_${wordIndex}`).children().first().click()
@@ -44,7 +33,7 @@ context('Onboarding - Create Mnemonic Wallet', () => {
     cy.getByTestID('verify_words_button').should('not.have.attr', 'disabled')
     cy.getByTestID('verify_words_button').click()
     // validate if they're the same words on return
-    numbers.forEach((i) => {
+    Array.from(Array(24), (v, i) => i + 1).forEach((i) => {
       cy.getByTestID(`word_${i}`).should('exist')
       cy.getByTestID(`word_${i}_number`).should('exist').contains(`${i}.`)
     })
@@ -52,64 +41,29 @@ context('Onboarding - Create Mnemonic Wallet', () => {
   })
 
   it('should be able to select correct words', function () {
-    [0, 1, 2, 3, 4, 5].forEach((key, index) => {
-      cy.getByTestID(`line_${index}`).then(($txt: any) => {
-        const wordIndex = (+$txt[0].textContent.replace('?', '').replace('#', '')) - 1
-        cy.getByTestID(`line_${index}_${recoveryWords[wordIndex]}`).click()
-      })
-    })
-  })
-
-  it('should be able to verify', function () {
-    cy.getByTestID('verify_words_button').should('not.have.attr', 'disabled')
-    cy.getByTestID('verify_words_button').click()
+    cy.selectMnemonicWords(recoveryWords)
   })
 
   it('should be able to verify and set pincode', function () {
-    cy.getByTestID('pin_input').type('000000')
-    cy.getByTestID('create_pin_button').click()
-    cy.getByTestID('pin_confirm_input').type('777777').wait(1000)
-    cy.getByTestID('wrong_passcode_text').should('exist')
-    cy.getByTestID('pin_confirm_input').type('000000')
+    cy.setupPinCode()
   })
 
   context('Settings - Mnemonic Verification', () => {
     it('should be able to verify mnemonic from settings page', function () {
-      cy.getByTestID('balances_list').should('exist')
-      cy.getByTestID('bottom_tab_settings').click()
-      cy.getByTestID('view_recovery_words').click()
-      cy.getByTestID('pin_authorize').type('000000')
-    })
-
-    numbers.forEach((i) => {
-      it(`should display word #${i}`, function () {
-        cy.getByTestID(`word_${i}`).should('exist')
-        cy.getByTestID(`word_${i}_number`).should('exist').contains(`${i}.`)
-        cy.getByTestID(`word_${i}`).then(($txt: any) => {
-          settingsRecoveryWords.push($txt[0].textContent)
-        })
-      })
-    })
-
-    it('should be able to have equal words', function () {
-      expect(recoveryWords).to.deep.eq(settingsRecoveryWords)
+      cy.verifyMnemonicOnSettingsPage(settingsRecoveryWords, recoveryWords)
     })
   })
 
   context('Restore - Mnemonic Verification', () => {
     it('should be able to restore mnemonic words', function () {
       cy.exitWallet()
-      cy.getByTestID('restore_wallet_button').click()
-      settingsRecoveryWords.forEach((word, index) => {
-        cy.getByTestID(`recover_word_${index + 1}`).clear().type(word).blur()
-        cy.getByTestID(`recover_word_${index + 1}`).should('have.css', 'color', 'rgb(0, 0, 0)')
-      })
-      cy.getByTestID('recover_wallet_button').should('not.have.attr', 'disabled')
-      cy.getByTestID('recover_wallet_button').click()
-      cy.getByTestID('pin_input').type('000000')
-      cy.getByTestID('create_pin_button').click()
-      cy.getByTestID('pin_confirm_input').type('000000')
-      cy.getByTestID('balances_list').should('exist')
+      cy.restoreMnemonicWords(settingsRecoveryWords)
+    })
+  })
+
+  context('Settings - On Restore - Mnemonic Verification', () => {
+    it('should be able to verify mnemonic from settings page', function () {
+      cy.verifyMnemonicOnSettingsPage([], recoveryWords)
     })
   })
 })

--- a/cypress/integration/functional/wallet/balances/receive.spec.ts
+++ b/cypress/integration/functional/wallet/balances/receive.spec.ts
@@ -1,7 +1,7 @@
 context('Wallet - Receive', () => {
   before(function () {
     cy.createEmptyWallet(true)
-    cy.sendDFItoWallet()
+    cy.sendDFItoWallet().wait(10000)
     cy.fetchWalletBalance()
   })
 

--- a/cypress/integration/functional/wallet/dex/available_pool_pairs.spec.ts
+++ b/cypress/integration/functional/wallet/dex/available_pool_pairs.spec.ts
@@ -19,6 +19,7 @@ context('Wallet - DEX - Available Pool Pairs', () => {
       expect(text).to.contains('Pooled DFI')
       expect(text).to.contains('Pooled BTC')
     })
+    cy.getByTestID('apr_DFI_BTC').should('exist')
   })
 
   it('should have DFI-USDT PoolPair as 3rd', () => {
@@ -30,5 +31,6 @@ context('Wallet - DEX - Available Pool Pairs', () => {
       expect(text).to.contains('Pooled DFI')
       expect(text).to.contains('Pooled USDT')
     })
+    cy.getByTestID('apr_DFI_USDT').should('exist')
   })
 })

--- a/cypress/integration/smoke/smoke.spec.ts
+++ b/cypress/integration/smoke/smoke.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * This file will be used for mainnet testing or smoke testing
+ * It will only test core features that doesn't require balances (e.g, Create, Restore wallet etc.)
+ * Tests included here are not that extensive compared to functional testing (e.g, Color, disable test or styling tests won't be added here)
+ * The goal is to have run smoke testing in Mainnet
+ * */
+
+context('Mainnet - Wallet', () => {
+  const recoveryWords: string[] = []
+  const settingsRecoveryWords: string[] = []
+  const localAddress = {
+    address: ''
+  }
+  const mainnetAddress = {
+    address: ''
+  }
+
+  beforeEach(() => {
+    cy.restoreLocalStorage()
+  })
+
+  afterEach(() => {
+    cy.saveLocalStorage()
+  })
+
+  it('should store values of local wallet', function () {
+    cy.createEmptyWallet(true)
+    cy.sendDFItoWallet()
+      .sendDFITokentoWallet()
+      .sendTokenToWallet(['BTC', 'DFI-ETH']).wait(10000)
+    cy.fetchWalletBalance()
+    cy.verifyWalletAddress('regtest', localAddress)
+  })
+
+  it('should have MainNet and Connected status', function () {
+    cy.switchNetwork('MainNet')
+    cy.isNetworkConnected('MainNet')
+  })
+
+  it('should start creation of mnemonic wallet', function () {
+    cy.startCreateMnemonicWallet(recoveryWords)
+  })
+
+  it('should be able to select correct words', function () {
+    cy.selectMnemonicWords(recoveryWords)
+  })
+
+  it('should be able to verify and set pincode', function () {
+    cy.setupPinCode()
+  })
+
+  context('Settings - Mnemonic Verification', () => {
+    it('should be able to verify mnemonic from settings page', function () {
+      cy.verifyMnemonicOnSettingsPage(settingsRecoveryWords, recoveryWords)
+    })
+  })
+
+  context('Restore - Mnemonic Verification', () => {
+    it('should be able to restore mnemonic words', function () {
+      cy.getByTestID('bottom_tab_settings').click()
+      cy.getByTestID('setting_exit_wallet').click()
+      cy.restoreMnemonicWords(settingsRecoveryWords)
+    })
+  })
+
+  context('Wallet - Verify Wallet Address', () => {
+    it('should be have selected valid network', function () {
+      cy.getByTestID('bottom_tab_settings').click()
+      cy.getByTestID('button_network_MainNet_check').should('exist')
+    })
+
+    it('should be have valid network address', function () {
+      cy.verifyWalletAddress('mainnet', mainnetAddress)
+      cy.getByTestID('bottom_tab_balances').click()
+    })
+  })
+
+  context('Wallet - On Refresh', () => {
+    it('should load selected network', function () {
+      cy.reload()
+      cy.isNetworkConnected('MainNet')
+      cy.getByTestID('bottom_tab_balances').click()
+      cy.getByTestID('balances_row_0_utxo').click()
+      cy.getByTestID('receive_button').click()
+      cy.getByTestID('address_text').then(($txt: any) => {
+        const address = $txt[0].textContent
+        expect(address).eq(mainnetAddress.address)
+      })
+    })
+  })
+
+  // In this test, there are Local and MainNet wallets existing
+  context('Wallet - Network Switch', () => {
+    it('should change network to Local', function () {
+      cy.getByTestID('bottom_tab_settings').click()
+      cy.getByTestID('button_network_Local').click()
+    })
+
+    it('should have correct balances', function () {
+      cy.fetchWalletBalance()
+      cy.getByTestID('bottom_tab_balances').click()
+      cy.getByTestID('balances_list').should('exist')
+      cy.getByTestID('balances_row_0_utxo_amount').contains(10)
+      cy.getByTestID('balances_row_0_amount').contains(10)
+      cy.getByTestID('balances_row_1_amount').contains(10)
+      cy.getByTestID('balances_row_7_amount').contains(10)
+    })
+
+    it('should have correct poolpairs', function () {
+      cy.getByTestID('bottom_tab_dex').click()
+      cy.getByTestID('your_DFI-BTC').contains('10.00 DFI-BTC')
+    })
+
+    it('should have correct address', function () {
+      cy.getByTestID('bottom_tab_balances').click()
+      cy.getByTestID('balances_row_0_utxo').click()
+      cy.getByTestID('receive_button').click()
+      cy.getByTestID('address_text').then(($txt: any) => {
+        const address = $txt[0].textContent
+        expect(address).eq(localAddress.address)
+      })
+    })
+  })
+})

--- a/cypress/integration/smoke/smoke.spec.ts
+++ b/cypress/integration/smoke/smoke.spec.ts
@@ -108,7 +108,7 @@ context('Mainnet - Wallet', () => {
 
     it('should have correct poolpairs', function () {
       cy.getByTestID('bottom_tab_dex').click()
-      cy.getByTestID('your_DFI-BTC').contains('10.00 DFI-BTC')
+      cy.getByTestID('your_DFI-ETH').contains('10.00 DFI-ETH')
     })
 
     it('should have correct address', function () {

--- a/cypress/integration/smoke/smoke.spec.ts
+++ b/cypress/integration/smoke/smoke.spec.ts
@@ -32,9 +32,9 @@ context('Mainnet - Wallet', () => {
     cy.verifyWalletAddress('regtest', localAddress)
   })
 
-  it('should have MainNet and Connected status', function () {
+  it('should have MainNet', function () {
+    cy.isNetworkConnected('Local')
     cy.switchNetwork('MainNet')
-    cy.isNetworkConnected('MainNet')
   })
 
   it('should start creation of mnemonic wallet', function () {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,4 +1,6 @@
 import '@testing-library/cypress/add-commands'
+import './onboardingCommands'
+import './walletCommands'
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
@@ -77,6 +79,23 @@ declare global {
        * @example cy.fetchWalletBalance()
        */
       fetchWalletBalance (): Chainable<Element>
+
+      /**
+       * @description Switch networks via app
+       * @param {string} network to be used
+       * @example cy.switchToMainnet('MainNet')
+       */
+      switchNetwork (network: string): Chainable<Element>
+
+      /**
+       * @description Stores local storage for dependent tests
+       */
+      saveLocalStorage (): Chainable<Element>
+
+      /**
+       * @description Restores local storage for dependent tests
+       */
+      restoreLocalStorage (): Chainable<Element>
     }
   }
 }
@@ -122,3 +141,22 @@ Cypress.Commands.add('exitWallet', () => {
 Cypress.Commands.add('fetchWalletBalance', () => {
   cy.getByTestID('playground_wallet_fetch_balances').click()
 })
+
+Cypress.Commands.add('switchNetwork', (network: string) => {
+  cy.getByTestID('bottom_tab_settings').click()
+  cy.getByTestID(`button_network_${network}`).click()
+})
+
+let LOCAL_STORAGE_MEMORY = {};
+
+Cypress.Commands.add('saveLocalStorage', () => {
+  Object.keys(localStorage).forEach(key => {
+    LOCAL_STORAGE_MEMORY[key] = localStorage[key];
+  });
+});
+
+Cypress.Commands.add('restoreLocalStorage', () => {
+  Object.keys(LOCAL_STORAGE_MEMORY).forEach(key => {
+    localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
+  });
+});

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -18,6 +18,6 @@ import './commands'
 
 Cypress.Server.defaults({
   ignore: (xhr: Request) => {
-    return xhr.url.match(/^.+\/v0\/playground\/(info|wallet)$/)
+    return xhr.url.match(/^.+\/v0\/(playground)\/.+$/)
   }
 })

--- a/cypress/support/onboardingCommands.ts
+++ b/cypress/support/onboardingCommands.ts
@@ -1,0 +1,106 @@
+import '@testing-library/cypress/add-commands'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * @description Start onboarding mnemonic wallet process
+       * @param {string[]} recoveryWords - pass an empty array to be filled later
+       */
+      startCreateMnemonicWallet (recoveryWords: string[]): Chainable<Element>
+
+      /**
+       * @description Select mnemonic words from Verify Step
+       * @param {string[]} recoveryWords - list of recoveryWords
+       * @example cy.selectMnemonicWords(recoveryWords)
+       */
+      selectMnemonicWords (recoveryWords: string[]): Chainable<Element>
+
+      /**
+       * @description Setup pin code from Onboarding
+       */
+      setupPinCode (): Chainable<Element>
+
+      /**
+       * @description Verify created mnemonic words in Settings Page
+       * @param {string[]} settingsRecoveryWords - need to pass reference to be used on other steps
+       * @param {string[]} recoveryWords - recovery words from create page
+       * @example cy.verifyMnemonicOnSettingsPage(settingsRecoveryWords, recoveryWords)
+       */
+      verifyMnemonicOnSettingsPage (settingsRecoveryWords: string[], recoveryWords: string[]): Chainable<Element>
+
+      /**
+       * @description Restore wallet using mnemonic words
+       * @param {string[]} recoveryWords - recovery words to restore
+       * @example cy.restoreMnemonicWords(recoveryWords)
+       */
+      restoreMnemonicWords (recoveryWords: string[]): Chainable<Element>
+    }
+  }
+}
+
+Cypress.Commands.add('startCreateMnemonicWallet', (recoveryWords: string[]) => {
+  cy.getByTestID('create_wallet_button').click()
+  cy.getByTestID('guidelines_switch').click()
+  cy.getByTestID('create_recovery_words_button').click()
+  cy.url().should('include', 'wallet/mnemonic/create')
+  cy.wrap(Array.from(Array(24), (v, i) => i)).each((el, i) => {
+    cy.getByTestID(`word_${i + 1}`).should('exist')
+    cy.getByTestID(`word_${i + 1}_number`).should('exist').contains(`${i + 1}.`)
+    cy.getByTestID(`word_${i + 1}`).then(($txt: any) => {
+      recoveryWords.push($txt[0].textContent)
+    })
+  }).then(() => {
+    cy.getByTestID('verify_button').should('not.have.attr', 'disabled')
+    cy.getByTestID('verify_button').click()
+  })
+})
+
+Cypress.Commands.add('selectMnemonicWords', (recoveryWords: string[]) => {
+  Array.from(Array(6), (v, i) => i + 1).forEach((key, index) => {
+    cy.getByTestID(`line_${index}`).then(($txt: any) => {
+      const wordIndex = (+$txt[0].textContent.replace('?', '').replace('#', '')) - 1
+      cy.getByTestID(`line_${index}_${recoveryWords[wordIndex]}`).click()
+    })
+  })
+  cy.getByTestID('verify_words_button').should('not.have.attr', 'disabled')
+  cy.getByTestID('verify_words_button').click()
+})
+
+Cypress.Commands.add('setupPinCode', () => {
+  cy.getByTestID('pin_input').type('000000')
+  cy.getByTestID('create_pin_button').click()
+  cy.getByTestID('pin_confirm_input').type('777777').wait(1000)
+  cy.getByTestID('wrong_passcode_text').should('exist')
+  cy.getByTestID('pin_confirm_input').type('000000')
+})
+
+Cypress.Commands.add('verifyMnemonicOnSettingsPage', function (settingsRecoveryWords: string[], recoveryWords: string[]) {
+  cy.getByTestID('balances_list').should('exist')
+  cy.getByTestID('bottom_tab_settings').click()
+  cy.getByTestID('view_recovery_words').click()
+  cy.getByTestID('pin_authorize').type('000000')
+  cy.wrap(Array.from(Array(24), (v, i) => i)).each((el, i) => {
+    cy.getByTestID(`word_${i + 1}`).should('exist')
+    cy.getByTestID(`word_${i + 1}_number`).should('exist').contains(`${i + 1}.`)
+    cy.getByTestID(`word_${i + 1}`).then(($txt: any) => {
+      settingsRecoveryWords.push($txt[0].textContent)
+    })
+  }).then(() => {
+    expect(recoveryWords).to.deep.eq(settingsRecoveryWords)
+  })
+})
+
+Cypress.Commands.add('restoreMnemonicWords', (recoveryWords: string[]) => {
+  cy.getByTestID('restore_wallet_button').click()
+  recoveryWords.forEach((word, index) => {
+    cy.getByTestID(`recover_word_${index + 1}`).clear().type(word).blur()
+    cy.getByTestID(`recover_word_${index + 1}`).should('have.css', 'color', 'rgb(0, 0, 0)')
+  })
+  cy.getByTestID('recover_wallet_button').should('not.have.attr', 'disabled')
+  cy.getByTestID('recover_wallet_button').click()
+  cy.getByTestID('pin_input').type('000000')
+  cy.getByTestID('create_pin_button').click()
+  cy.getByTestID('pin_confirm_input').type('000000')
+  cy.getByTestID('balances_list').should('exist')
+})

--- a/cypress/support/walletCommands.ts
+++ b/cypress/support/walletCommands.ts
@@ -1,0 +1,44 @@
+import { DeFiAddress } from "@defichain/jellyfish-address";
+import '@testing-library/cypress/add-commands'
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * @description Verify wallet address if it's a valid
+       * @param {string} network - network of wallet
+       * @param {string} addressObject - optional address if needs to be used on next steps
+       * @example cy.verifyWalletAddress(recoveryWords, address)
+       */
+      verifyWalletAddress (network: string, addressObject?: { address: string }): Chainable<Element>
+
+      /**
+       * @description Verify if connected to correct network
+       * @param {string} network - network of wallet
+       * @example cy.isNetworkConnected('MainNet')
+       */
+      isNetworkConnected (network: string): Chainable<Element>
+    }
+  }
+}
+
+Cypress.Commands.add('verifyWalletAddress', (network: string, addressObject?: { address: string }) => {
+  cy.getByTestID('bottom_tab_balances').click()
+  cy.getByTestID('balances_row_0_utxo').click()
+  cy.getByTestID('receive_button').click()
+  cy.getByTestID('address_text').then(($txt: any) => {
+    const a = $txt[0].textContent
+    if (addressObject) {
+      addressObject.address = a
+    }
+    expect(DeFiAddress.from(network, a).valid).eq(true)
+  })
+})
+
+Cypress.Commands.add('isNetworkConnected', (network: string) => {
+  cy.getByTestID('playground_active_network').then(($txt: any) => {
+    const network = $txt[0].textContent
+    expect(network).eq('MainNet')
+  })
+  cy.getByTestID('playground_status_indicator').should('have.css', 'background-color', 'rgb(16, 185, 129)')
+})

--- a/cypress/support/walletCommands.ts
+++ b/cypress/support/walletCommands.ts
@@ -36,9 +36,9 @@ Cypress.Commands.add('verifyWalletAddress', (network: string, addressObject?: { 
 })
 
 Cypress.Commands.add('isNetworkConnected', (network: string) => {
-  cy.getByTestID('playground_active_network').then(($txt: any) => {
-    const network = $txt[0].textContent
-    expect(network).eq('MainNet')
+  cy.getByTestID('header_active_network').then(($txt: any) => {
+    const net = $txt[0].textContent
+    expect(net).eq(network)
   })
-  cy.getByTestID('playground_status_indicator').should('have.css', 'background-color', 'rgb(16, 185, 129)')
+  cy.getByTestID('header_status_indicator').should('have.css', 'background-color', 'rgb(16, 185, 129)')
 })

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "ignore": [
       "**/*.test.ts",
       "**/*.test.tsx",
-      "cypress/support/commands.ts"
+      "cypress/support/*.ts"
     ]
   },
   "standard-version": {


### PR DESCRIPTION
#### What kind of PR is this?:
/kind fix
/kind refactor

#### What this PR does / why we need it:

Fixed #470 by removing `useConnectedPlayground()` which was deprecated, it auto-resolves the network on start by looking for a playground network to connect to. This implementation is just frustrating as it doesn't have a deterministic or static behavior to network resolution. DeFi Scan has removed this implementation recently as it was difficult to manage SSR and SPA network states, the resolution on DeFi Scan is now static too.
- This also fixes #473
- By removing `useConnectedPlayground()` playground local/remote resolution is now not automated anymore. By default, it will always resolve to the first network (which is "Local" for CI and development). During development, you must switch networks manually. And for e2e testing you must always use Local Network, you can start local network via `npm run playground:start`.
- To allow network switching easily during CI and testing, we can add it into "DeFi Playground", now "DeFi Testing".
- `PlaygroundScreen` has been refactored from "DeFi Playground" to "DeFi Testing" this refactor in large is to allow other networks to use the new "DeFi Testing" environment for features such as quick Wallet setup. A large part of the code into DeFi Playground has been refactored to be componentized. 

Fixed #471 by adding missing dependencies to `useMemo` in WalletAddressToken: `}, [wallet])`

Fixed #472 by deploying `whale:0.8.6`

Fixed #480 by adding a few missing dependencies to `useEffect`
- `}, [address])`
- `}, [wallet])`

Linked PRs: https://github.com/DeFiCh/wallet/pull/488 https://github.com/DeFiCh/wallet/pull/490

Fixed #423 #466

> I only tested these on `Web` and some parts of it on `Mobile`. @thedoublejay and someone else need to verify them

#### Additional comments?:

~~Many `useEffect` uses `}, [JSON.stringify(tokens)])` we should refactor this. `JSON.stringy()` shouldn't be a thing for `useEffect`. Many `useEffect` dependencies array is not well thought out, we need to be inspect them carefully.~~

Our context and provider are deeply nested which each resolution relying on a previous upstream provider/context this means if network changes whale will be updated, if whale is updated so must wallet, starting from: 
1. network
2. playground 
3. whale
4. wallet persistence 
5. defi scan
6. wallet store
7. wallet 
8. wallet address
9. transactions

```html
<ErrorBoundary>
  <NetworkProvider>
    <PlaygroundProvider>
      <WhaleProvider>
        <WalletPersistenceProvider>
          <DeFiScanProvider>
            <WalletStoreProvider>
              <SafeAreaProvider>
                <WalletNavigator />
                or
                <WalletProvider data={wallets[0]}>
                  <WalletAddressProvider>
                    <TransactionAuthorization />
                    <NavigationContainer>
                      <App.Navigator>
                        <App.Screen name='App' component={BottomTabNavigator} />
                        <App.Screen name='Playground' component={PlaygroundNavigator} />
                      </App.Navigator>
                    </NavigationContainer>
                  </WalletAddressProvider>
                </WalletProvider>
              </SafeAreaProvider>
            </WalletStoreProvider>
          </DeFiScanProvider>
        </WalletPersistenceProvider>
      </WhaleProvider>
    </PlaygroundProvider>
  </NetworkProvider>
</ErrorBoundary>
```