### PR TITLE
enabled TestNet on `environments.Production`

### DIFF
--- a/app/__snapshots__/environment.test.ts.snap
+++ b/app/__snapshots__/environment.test.ts.snap
@@ -31,6 +31,7 @@ Object {
   "name": "Production",
   "networks": Array [
     "MainNet",
+    "TestNet",
     "Playground",
   ],
 }

--- a/app/environment.ts
+++ b/app/environment.ts
@@ -28,7 +28,7 @@ export const environments: Record<EnvironmentName, Environment> = {
     debug: false,
     networks: [
       EnvironmentNetwork.MainNet,
-      // EnvironmentNetwork.TestNet, still having issues with this deployment in EU region due to peers issues
+      EnvironmentNetwork.TestNet,
       EnvironmentNetwork.RemotePlayground
     ]
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Ocean `TestNet` has been deployed successfully recently. This PR enabled TestNet on `environments.Production`.