### PR TITLE
ConnectionStatus to use different interval, 3000 for playground, 30000 for main/test

### DIFF
--- a/app/components/HeaderTitle.tsx
+++ b/app/components/HeaderTitle.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Logging } from '../api'
 import { useNetworkContext } from '../contexts/NetworkContext'
 import { useWhaleApiClient } from '../contexts/WhaleContext'
+import { isPlayground } from '../environment'
 import { RootState } from '../store'
 import { block } from '../store/block'
 import { tailwind } from '../tailwind'
@@ -34,7 +35,7 @@ export function ConnectionStatus (): JSX.Element {
 
     if (!isPolling) {
       refresh()
-      interval = setInterval(refresh, 3000)
+      interval = setInterval(refresh, isPlayground(network) ? 3000 : 30000)
     }
     return () => {
       dispatch(block.actions.setPolling(false))


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

To increase main/test net interval to 30,000