### PR TITLE
`send` - overflow long addresses in recipient address field

### DIFF
--- a/app/screens/AppNavigator/screens/Balances/screens/SendScreen.tsx
+++ b/app/screens/AppNavigator/screens/Balances/screens/SendScreen.tsx
@@ -176,12 +176,13 @@ function AddressRow ({
           <View style={tailwind('flex-row w-full')}>
             <TextInput
               testID='address_input'
-              style={tailwind('flex-grow p-4 bg-white')}
+              style={tailwind('w-4/5 flex-grow p-4 pr-0 bg-white')}
               autoCapitalize='none'
               value={value}
               onBlur={onBlur}
               onChangeText={onChange}
               placeholder={translate('screens/SendScreen', 'Enter an address')}
+              multiline
             />
             <TouchableOpacity
               testID='qr_code_button'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
- To allow full visibility of address of recipient
- To allow user to access scan QR button function when address is long

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #518

#### Additional comments?:
Tested on iPhone 12 and Pixel 3a