### PR TITLE
`ci-e2e.yml` to setup container and install npm concurrently

### DIFF
--- a/.github/workflows/ci-drift.yml
+++ b/.github/workflows/ci-drift.yml
@@ -1,4 +1,4 @@
-name: Drift Detection
+name: CI Drift
 
 on:
   pull_request:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -1,4 +1,4 @@
-name: CI - E2E
+name: CI E2E
 
 on:
   workflow_dispatch:
@@ -20,15 +20,16 @@ jobs:
         containers: [ 1, 2, 3, 4, 5, 6 ]
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - name: Setup Playground
+        run: docker-compose -f docker-compose.yml up -d
+
       - uses: actions/setup-node@25316bbc1f10ac9d8798711f44914b1cf3c4e954
         with:
           node-version: 15
           cache: 'npm'
 
       - run: npm ci
-
-      - name: Setup Playground
-        run: docker-compose -f docker-compose.yml up -d
 
       - run: .github/workflows/ci/wait-for http://localhost:3001/_actuator/probes/liveness -t 120
       - run: .github/workflows/ci/wait-for http://localhost:3002/_actuator/probes/liveness -t 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
+    - cron: '0 9 * * *'
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-node@25316bbc1f10ac9d8798711f44914b1cf3c4e954
         with:
           node-version: 15
+          cache: 'npm'
 
       - uses: expo/expo-github-action@c3c02de017ef8cf6152daee160e8a47a2340a5e5
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

The playground containers take time to be ready, this PR moves the container init before npm install allowing for better performance and faster test time. Chopping off 30 seconds on average.

Also in this PR, prefixed CI to be `ci-*.yml` and set up workflow dispatch and cron for ci.

