### PR TITLE
`ocean interface` - incorrect size on change passcode

### DIFF
--- a/app/screens/AppNavigator/screens/Balances/BalancesScreen.test.tsx
+++ b/app/screens/AppNavigator/screens/Balances/BalancesScreen.test.tsx
@@ -48,6 +48,14 @@ jest.mock("../../../../contexts/WalletContext", () => ({
   }
 }));
 
+jest.mock("../../../../contexts/WalletPersistenceContext", () => ({
+  useWalletPersistenceContext: () => {
+    return {
+      wallets: []
+    }
+  }
+}));
+
 describe('balances page', () => {
   it('should match snapshot', async () => {
     const initialState: Partial<RootState> = {

--- a/app/screens/AppNavigator/screens/Balances/BalancesScreen.tsx
+++ b/app/screens/AppNavigator/screens/Balances/BalancesScreen.tsx
@@ -10,6 +10,7 @@ import { Text, View } from '../../../../components'
 import { getTokenIcon } from '../../../../components/icons/tokens/_index'
 import { SectionTitle } from '../../../../components/SectionTitle'
 import { useWalletContext } from '../../../../contexts/WalletContext'
+import { useWalletPersistenceContext } from '../../../../contexts/WalletPersistenceContext'
 import { useWhaleApiClient } from '../../../../contexts/WhaleContext'
 import { fetchTokens, useTokensAPI } from '../../../../hooks/wallet/TokensAPI'
 import { ocean } from '../../../../store/ocean'
@@ -26,10 +27,11 @@ export function BalancesScreen ({ navigation }: Props): JSX.Element {
   const { address } = useWalletContext()
   const [refreshing, setRefreshing] = useState(false)
   const dispatch = useDispatch()
+  const { wallets } = useWalletPersistenceContext()
 
   useEffect(() => {
     dispatch(ocean.actions.setHeight(height))
-  }, [height])
+  }, [height, wallets])
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true)

--- a/app/store/ocean.test.ts
+++ b/app/store/ocean.test.ts
@@ -9,7 +9,7 @@ describe('ocean reducer', () => {
   beforeEach(() => {
     initialState = {
       transactions: [],
-      height: 49,
+      height: 0,
       err: undefined
     }
   })
@@ -18,7 +18,7 @@ describe('ocean reducer', () => {
     expect(ocean.reducer(undefined, { type: 'unknown' })).toEqual({
       transactions: [],
       err: undefined,
-      height: 49
+      height: 0
     });
   })
 
@@ -31,22 +31,22 @@ describe('ocean reducer', () => {
     expect(addedTransaction).toStrictEqual({ transactions: [{
       ...payload,
       broadcasted: false
-    }], err: undefined, height: 49 })
+    }], err: undefined, height: 0 })
     const actual = ocean.reducer(addedTransaction, ocean.actions.queueTransaction(payload));
 
     const pop = ocean.reducer(actual, ocean.actions.popTransaction());
     expect(pop).toStrictEqual({ transactions: [{
       ...payload,
       broadcasted: false
-    }], err: undefined, height: 49 })
+    }], err: undefined, height: 0 })
     const removed = ocean.reducer(pop, ocean.actions.popTransaction());
-    expect(removed).toStrictEqual({ transactions: [], err: undefined, height: 49 })
+    expect(removed).toStrictEqual({ transactions: [], err: undefined, height: 0 })
   })
 
   it('should handle setError', () => {
     const err = new Error('An error has occurred')
     const actual = ocean.reducer(initialState, ocean.actions.setError(err));
-    expect(actual).toStrictEqual({ transactions: [], err, height: 49 })
+    expect(actual).toStrictEqual({ transactions: [], err, height: 0 })
   })
 
   it('should setHeight', () => {

--- a/app/store/ocean.ts
+++ b/app/store/ocean.ts
@@ -16,7 +16,7 @@ export interface OceanState {
 
 const initialState: OceanState = {
   transactions: [],
-  height: 49,
+  height: 0,
   err: undefined
 }
 


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
- To fix ocean interface height from going back to initial height upon resetting wallet after changing passcode successfully

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
- Fixes #603

#### Additional comments?:
- Tested on iPhone 12 & pixel 3a emulator