### PR TITLE
`restore` - add warning popup when exiting a filled form

### DIFF
--- a/app/screens/WalletNavigator/screens/RestoreWallet/RestoreMnemonicWallet.tsx
+++ b/app/screens/WalletNavigator/screens/RestoreWallet/RestoreMnemonicWallet.tsx
@@ -57,6 +57,10 @@ export function RestoreMnemonicWallet (): JSX.Element {
           ]
         )
       })
+      return () => {
+        navigation.removeListener('beforeRemove', () => {
+        })
+      }
     }
   }, [navigation, isDirty])
 

--- a/app/screens/WalletNavigator/screens/RestoreWallet/RestoreMnemonicWallet.tsx
+++ b/app/screens/WalletNavigator/screens/RestoreWallet/RestoreMnemonicWallet.tsx
@@ -3,7 +3,7 @@ import { NavigationProp, useNavigation } from '@react-navigation/native'
 import * as React from 'react'
 import { createRef, useEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
-import { Alert, TextInput } from 'react-native'
+import { Alert, Platform, TextInput } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { Text, View } from '../../../../components'
 import { Button } from '../../../../components/Button'
@@ -15,7 +15,7 @@ import { WalletParamList } from '../../WalletNavigator'
 
 export function RestoreMnemonicWallet (): JSX.Element {
   const navigation = useNavigation<NavigationProp<WalletParamList>>()
-  const { control, formState: { isValid }, getValues } = useForm({ mode: 'onChange' })
+  const { control, formState: { isValid, isDirty }, getValues } = useForm({ mode: 'onChange' })
   const [recoveryWords] = useState<number[]>(Array.from(Array(24), (v, i) => i + 1))
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [inputRefMap, setInputRefMap] = useState<Array<React.RefObject<TextInput>>>([])
@@ -26,6 +26,39 @@ export function RestoreMnemonicWallet (): JSX.Element {
       setInputRefMap(inputRefMap)
     })
   }, [])
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') {
+      navigation.addListener('beforeRemove', (e) => {
+        if (!isDirty) {
+          // If we don't have unsaved changes, then we don't need to do anything
+          return
+        }
+
+        // Prevent default behavior of leaving the screen
+        e.preventDefault()
+
+        // Prompt the user before leaving the screen
+        Alert.alert(
+          translate('screens/RestoreWallet', 'Discard changes?'),
+          translate('screens/RestoreWallet', 'You have unsaved changes. Are you sure to discard them and leave the screen?'),
+          [
+            {
+              text: 'Cancel',
+              style: 'cancel',
+              onPress: () => {
+              }
+            },
+            {
+              text: 'Discard',
+              style: 'destructive',
+              onPress: () => navigation.dispatch(e.data.action)
+            }
+          ]
+        )
+      })
+    }
+  }, [navigation, isDirty])
 
   if (inputRefMap.length < 24) {
     return <></>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
1. Add a warning popup when user has a filled form in Restore Mnemonic page. This is to prevent accidental exit and restarting again
#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
![Image from iOS](https://user-images.githubusercontent.com/25013382/129513295-a2e76e3e-77e5-4d39-818d-389322c2576a.png)
