### PR TITLE
refactor to `npm run lint` instead of `npm run standard`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,19 @@
+{
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "extends": [
+    "standard-with-typescript",
+    "standard-jsx"
+  ],
+  "ignorePatterns": [
+    "*.json",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "cypress/support/*.ts"
+  ],
+  "rules": {
+    "import/no-default-export": "warn"
+  },
+  "overrides": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
-      - run: npx --no-install ts-standard
+      - run: npx --no-install eslint app App.tsx
 
   unit:
     name: Unit Test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "prepare": "husky install",
-    "standard": "ts-standard --fix",
+    "lint": "eslint app App.tsx --fix",
     "start": "expo start",
     "start:android": "expo start --android",
     "start:ios": "expo start --ios",
@@ -113,14 +113,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js}": [
-      "npm run standard"
-    ]
-  },
-  "ts-standard": {
-    "ignore": [
-      "**/*.test.ts",
-      "**/*.test.tsx",
-      "cypress/support/*.ts"
+      "npm run lint"
     ]
   },
   "standard-version": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

Same lint style but using `eslint` runner by default for better IDE integration and customizable to expo defaults.
