### PR TITLE
refactor to `mnemonic_storage.ts` to use `entropyAsMnemonic` & `mnemonicAsEntropy`

### DIFF
--- a/app/screens/AppNavigator/screens/Settings/SettingsScreen.tsx
+++ b/app/screens/AppNavigator/screens/Settings/SettingsScreen.tsx
@@ -6,7 +6,7 @@ import { useCallback } from 'react'
 import { Alert, Platform, ScrollView, TouchableOpacity } from 'react-native'
 import { useDispatch } from 'react-redux'
 import { Logging } from '../../../../api'
-import { MnemonicWords } from '../../../../api/wallet/mnemonic_words'
+import { MnemonicStorage } from '../../../../api/wallet/mnemonic_storage'
 import { Text } from '../../../../components'
 import { SectionTitle } from '../../../../components/SectionTitle'
 import { useWalletPersistenceContext } from '../../../../contexts/WalletPersistenceContext'
@@ -34,7 +34,7 @@ export function SettingsScreen ({ navigation }: Props): JSX.Element {
 
     const auth: Authentication<string[]> = {
       message: translate('screens/Settings', 'To continue downloading your recovery words, we need you to enter your passcode.'),
-      consume: async passphrase => await MnemonicWords.decrypt(passphrase),
+      consume: async passphrase => await MnemonicStorage.get(passphrase),
       onAuthenticated: async (words) => {
         navigation.navigate({ name: 'RecoveryWordsScreen', params: { words }, merge: true })
       },
@@ -50,7 +50,7 @@ export function SettingsScreen ({ navigation }: Props): JSX.Element {
 
     const auth: Authentication<string[]> = {
       message: translate('screens/Settings', 'To update your passcode, we need you to enter your current passcode.'),
-      consume: async passphrase => await MnemonicWords.decrypt(passphrase),
+      consume: async passphrase => await MnemonicStorage.get(passphrase),
       onAuthenticated: async words => {
         navigation.navigate({
           name: 'ChangePinScreen', params: { words, pinLength: 6 }, merge: true

--- a/app/screens/AppNavigator/screens/Settings/screens/ConfirmPinScreen.tsx
+++ b/app/screens/AppNavigator/screens/Settings/screens/ConfirmPinScreen.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 import { ActivityIndicator, ScrollView } from 'react-native'
 import { Logging } from '../../../../../api'
 import { MnemonicEncrypted } from '../../../../../api/wallet'
-import { MnemonicWords } from '../../../../../api/wallet/mnemonic_words'
+import { MnemonicStorage } from '../../../../../api/wallet/mnemonic_storage'
 import { Text, View } from '../../../../../components'
 import { PinTextInput } from '../../../../../components/PinTextInput'
 import { useNetworkContext } from '../../../../../contexts/NetworkContext'
@@ -40,7 +40,7 @@ export function ConfirmPinScreen ({ route }: Props): JSX.Element {
     setTimeout(() => {
       MnemonicEncrypted.toData(copy.words, copy.network, copy.pin)
         .then(async encrypted => {
-          await MnemonicWords.encrypt(words, pin)
+          await MnemonicStorage.set(words, pin)
           await setWallet(encrypted)
           navigation.dispatch(StackActions.popToTop())
           // if (biometricEnrolled) BiometricProtectedPasscode.set(pin)

--- a/app/screens/PlaygroundNavigator/sections/PlaygroundWallet.tsx
+++ b/app/screens/PlaygroundNavigator/sections/PlaygroundWallet.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { MnemonicEncrypted, MnemonicUnprotected } from '../../../api/wallet'
-import { MnemonicWords } from '../../../api/wallet/mnemonic_words'
+import { MnemonicStorage } from '../../../api/wallet/mnemonic_storage'
 import { View } from '../../../components'
 import { useNetworkContext } from '../../../contexts/NetworkContext'
 import { useWalletPersistenceContext } from '../../../contexts/WalletPersistenceContext'
@@ -53,7 +53,7 @@ export function PlaygroundWallet (): JSX.Element | null {
           const words = MnemonicUnprotected.generateWords()
           const encrypted = await MnemonicEncrypted.toData(words, network, '000000')
           await setWallet(encrypted)
-          await MnemonicWords.encrypt(words, '000000')
+          await MnemonicStorage.set(words, '000000')
         }}
       />
     </View>

--- a/app/screens/WalletNavigator/screens/CreateWallet/EnrollBiometric.tsx
+++ b/app/screens/WalletNavigator/screens/CreateWallet/EnrollBiometric.tsx
@@ -6,7 +6,7 @@ import { Platform, ScrollView, Switch } from 'react-native'
 import tailwind from 'tailwind-rn'
 import { Logging } from '../../../../api'
 import { BiometricProtectedPasscode } from '../../../../api/wallet/biometric_protected_passcode'
-import { MnemonicWords } from '../../../../api/wallet/mnemonic_words'
+import { MnemonicStorage } from '../../../../api/wallet/mnemonic_storage'
 import { Text, View } from '../../../../components'
 import { Button } from '../../../../components/Button'
 import { FaceIdIcon } from '../../../../components/icons/FaceIdIcon'
@@ -42,7 +42,7 @@ export function EnrollBiometric ({ route }: Props): JSX.Element {
 
   const onComplete = useCallback(async () => {
     await setWallet(encrypted)
-    await MnemonicWords.encrypt(words, pin)
+    await MnemonicStorage.set(words, pin)
   }, [])
 
   useEffect(() => {

--- a/app/screens/WalletNavigator/screens/CreateWallet/PinConfirmation.tsx
+++ b/app/screens/WalletNavigator/screens/CreateWallet/PinConfirmation.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 import { ActivityIndicator, ScrollView } from 'react-native'
 import { Logging } from '../../../../api'
 import { MnemonicEncrypted } from '../../../../api/wallet'
-import { MnemonicWords } from '../../../../api/wallet/mnemonic_words'
+import { MnemonicStorage } from '../../../../api/wallet/mnemonic_storage'
 import { Text, View } from '../../../../components'
 import {
   CREATE_STEPS,
@@ -45,7 +45,7 @@ export function PinConfirmation ({ route }: Props): JSX.Element {
     setTimeout(() => {
       MnemonicEncrypted.toData(copy.words, copy.network, copy.pin)
         .then(async encrypted => {
-          await MnemonicWords.encrypt(words, pin)
+          await MnemonicStorage.set(words, pin)
           await setWallet(encrypted)
 
           // temp disabled biometric, forward data to biometric enrolment page after more test


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

Refactor to `mnemonic_storage.ts` to use `entropyAsMnemonic` & `mnemonicAsEntropy`.

With this, the entropy will always be at 32 bytes, it will not require us to pad for encryption.