### PR TITLE
Added `WalletNodeContext` so that `TransactionAuthorization` doesn't use Persistence layer

### DIFF
--- a/app/contexts/WalletNodeProvider.tsx
+++ b/app/contexts/WalletNodeProvider.tsx
@@ -1,0 +1,84 @@
+import { WalletHdNode, WalletHdNodeProvider } from '@defichain/jellyfish-wallet'
+import { EncryptedProviderData } from '@defichain/jellyfish-wallet-encrypted'
+import { MnemonicProviderData } from '@defichain/jellyfish-wallet-mnemonic'
+import React, { createContext, PropsWithChildren, useContext, useMemo } from 'react'
+import { MnemonicEncrypted, MnemonicUnprotected, WalletPersistenceData, WalletType } from '../api/wallet'
+import { useNetworkContext } from './NetworkContext'
+
+interface WalletNodeContextI {
+  provider: WalletHdNodeProvider<WalletHdNode>
+  /**
+   * Raw WalletPersistenceData that is included in WalletHdNodeProvider<WalletHdNode>
+   * No risk of including it in context as it's part of the provider.
+   */
+  data: WalletPersistenceData<any>
+}
+
+const WalletNodeContext = createContext<WalletNodeContextI>(undefined as any)
+
+export function useWalletNodeContext (): WalletNodeContextI {
+  return useContext(WalletNodeContext)
+}
+
+interface WalletNodeProviderProps<T> extends PropsWithChildren<any> {
+  data: WalletPersistenceData<T>
+}
+
+/**
+ * Automatically determine the correct WalletProvider to use based on the wallet type.
+ */
+export function WalletNodeProvider (props: WalletNodeProviderProps<any>): JSX.Element | null {
+  if (props.data.type === WalletType.MNEMONIC_UNPROTECTED) {
+    return (
+      <MnemonicUnprotectedProvider {...props}>
+        {props.children}
+      </MnemonicUnprotectedProvider>
+    )
+  }
+
+  if (props.data.type === WalletType.MNEMONIC_ENCRYPTED) {
+    return (
+      <MnemonicEncryptedProvider {...props}>
+        {props.children}
+      </MnemonicEncryptedProvider>
+    )
+  }
+
+  throw new Error(`wallet type: ${props.data.type as string} not available`)
+}
+
+function MnemonicUnprotectedProvider (props: WalletNodeProviderProps<MnemonicProviderData>): JSX.Element | null {
+  const { network } = useNetworkContext()
+
+  const provider = useMemo(() => {
+    return MnemonicUnprotected.initProvider(props.data, network)
+  }, [network, props.data])
+
+  return (
+    <WalletNodeContext.Provider value={{ provider, data: props.data }}>
+      {props.children}
+    </WalletNodeContext.Provider>
+  )
+}
+
+function MnemonicEncryptedProvider (props: WalletNodeProviderProps<EncryptedProviderData>): JSX.Element | null {
+  const { network } = useNetworkContext()
+
+  const provider = useMemo(() => {
+    return MnemonicEncrypted.initProvider(props.data, network, {
+      /**
+       * wallet context only use for READ purpose (non signing)
+       * see {@link TransactionAuthorization} for signing implementation
+       */
+      async prompt () {
+        throw new Error('No UI attached for passphrase prompting')
+      }
+    })
+  }, [network, props.data])
+
+  return (
+    <WalletNodeContext.Provider value={{ provider, data: props.data }}>
+      {props.children}
+    </WalletNodeContext.Provider>
+  )
+}

--- a/app/screens/PlaygroundNavigator/PlaygroundScreen.tsx
+++ b/app/screens/PlaygroundNavigator/PlaygroundScreen.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { ScrollView } from 'react-native'
 import { useNetworkContext } from '../../contexts/NetworkContext'
-import { WalletProvider } from '../../contexts/WalletContext'
+import { WalletContextProvider } from '../../contexts/WalletContext'
+import { WalletNodeProvider } from '../../contexts/WalletNodeProvider'
 import { useWalletPersistenceContext } from '../../contexts/WalletPersistenceContext'
 import { isPlayground } from '../../environment'
 import { tailwind } from '../../tailwind'
@@ -33,9 +34,11 @@ function PlaygroundWalletSection (): JSX.Element | null {
   }
 
   return (
-    <WalletProvider data={wallets[0]}>
-      <PlaygroundUTXO />
-      <PlaygroundToken />
-    </WalletProvider>
+    <WalletNodeProvider data={wallets[0]}>
+      <WalletContextProvider>
+        <PlaygroundUTXO />
+        <PlaygroundToken />
+      </WalletContextProvider>
+    </WalletNodeProvider>
   )
 }

--- a/app/screens/RootNavigator.tsx
+++ b/app/screens/RootNavigator.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { WalletProvider } from '../contexts/WalletContext'
+import { WalletContextProvider } from '../contexts/WalletContext'
+import { WalletNodeProvider } from '../contexts/WalletNodeProvider'
 import { useWalletPersistenceContext } from '../contexts/WalletPersistenceContext'
 import { AppNavigator } from './AppNavigator/AppNavigator'
 import { TransactionAuthorization } from './TransactionAuthorization'
@@ -21,9 +22,11 @@ export function RootNavigator (): JSX.Element {
   }
 
   return (
-    <WalletProvider data={wallets[0]}>
-      <TransactionAuthorization />
-      <AppNavigator />
-    </WalletProvider>
+    <WalletNodeProvider data={wallets[0]}>
+      <WalletContextProvider>
+        <TransactionAuthorization />
+        <AppNavigator />
+      </WalletContextProvider>
+    </WalletNodeProvider>
   )
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

Added `WalletNodeContext` so that `TransactionAuthorization` doesn't use `WalletPersistence` layer for future evolving code reasons.

Thus this allow `TransactionAuthorization` to access provider data via `useWalletNodeContext()`.

```ts
const { data: providerData } = useWalletNodeContext()
```
