### PR TITLE
added `.imgbotconfig` to ignore cypress image snapshot

### DIFF
--- a/.imgbotconfig
+++ b/.imgbotconfig
@@ -1,0 +1,6 @@
+{
+    "schedule": "daily",
+    "ignoredFiles": [
+    	"cypress/**"
+    ]
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

`/cypress/**` images are part of cypress visual regression.