### PR TITLE
added github workflow concurrency to cancel in progress when new workflow is triggered

### DIFF
--- a/.github/workflows/ci-drift.yml
+++ b/.github/workflows/ci-drift.yml
@@ -6,6 +6,10 @@ on:
     paths-ignore:
       - '**.md'
 
+concurrency:
+  group: ${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tailwind:
     name: Tailwind

--- a/.github/workflows/ci-drift.yml
+++ b/.github/workflows/ci-drift.yml
@@ -7,7 +7,7 @@ on:
       - '**.md'
 
 concurrency:
-  group: ${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Cypress

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/eas-publish.yml
+++ b/.github/workflows/eas-publish.yml
@@ -1,9 +1,12 @@
-name: Publish
+name: EAS Publish
 
 on:
   release:
-    types: [ published, prereleased ]
+    types: [ published ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   version:

--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -6,6 +6,10 @@ on:
     paths-ignore:
       - '**.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-preview:
     if: github.event.sender.type == 'User' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/expo-publish.yml
+++ b/.github/workflows/expo-publish.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: Publish

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DeFiChain Wallet has 3 releases channel and unique environment for each of those
 <summary><b>Production</b></summary>
 
 Created by Expo Application Service and configured in [`eas.json`](/eas.json), it creates a native build
-with [`release-publish.yml`](/.github/workflows/release-publish.yml) workflow on type "published". Builds can only be
+with [`release-publish.yml`](/.github/workflows/eas-publish.yml) workflow on type "published". Builds can only be
 triggered by DeFiChain engineers, they are automatically uploaded into native app store for distribution.
 
 In the production environment, only **MainNet** is available, and debugging is not enabled.
@@ -28,7 +28,7 @@ In the production environment, only **MainNet** is available, and debugging is n
 
 Preview builds are created by 2 workflow. First at each pull request
 via [`expo-preview.yml`](/.github/workflows/expo-preview.yml) workflow, release are prefixed `pr-preview-`. Secondly
-at  [`release-publish.yml`](/.github/workflows/release-publish.yml) workflow on type "prereleased".
+at  [`release-publish.yml`](/.github/workflows/eas-publish.yml) workflow on type "prereleased".
 
 In the preview environment, all networks are available, and debugging is enabled.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Usually, the old workflow run is discarded and rendered useless, this change will kill it immediately saving runner concurrency count to achieve faster throughput for workflow.