### PR TITLE
`convert` - auto deduct 0.1 DFI UTXO when converting max amount

### DIFF
--- a/cypress/integration/functional/wallet/balances/convert/convert.spec.ts
+++ b/cypress/integration/functional/wallet/balances/convert/convert.spec.ts
@@ -14,6 +14,12 @@ function createDFIWallet (): void {
   cy.getByTestID('convert_button').click()
 }
 
+function navigateToConvertScreen (): void {
+  cy.getByTestID('bottom_tab_balances').click()
+  cy.getByTestID('balances_row_0_utxo').click()
+  cy.getByTestID('convert_button').click()
+}
+
 context('Wallet - Convert DFI', () => {
   before(function () {
     createDFIWallet()
@@ -127,5 +133,52 @@ context('Wallet - Convert Account to UTXO', function () {
 
     cy.getByTestID('balances_row_0_utxo_amount').contains('20.999')
     cy.getByTestID('balances_row_0_amount').contains('9')
+  })
+})
+
+context('Wallet - Convert UTXO to Account with at least 0.1 UTXO in Balance', function () {
+  before(function () {
+    createDFIWallet()
+  })
+
+  it('should disable continue button if UTXO balance after conversion is less than 0.1 DFI UTXO', function () {
+    cy.getByTestID('text_input_convert_from_input').clear().type('20')
+    cy.getByTestID('button_continue_convert').should('have.attr', 'disabled')
+    cy.getByTestID('text_input_convert_from_input').clear().type('19.90000001')
+    cy.getByTestID('button_continue_convert').should('have.attr', 'disabled')
+  })
+
+  it('should enable continue button if UTXO balance after conversion is greater than or equal to 0.1 DFI UTXO', function () {
+    cy.getByTestID('text_input_convert_from_input').clear().type('19.9')
+    cy.getByTestID('button_continue_convert').should('not.have.attr', 'disabled')
+    cy.getByTestID('text_input_convert_from_input').clear().type('0.00000001')
+    cy.getByTestID('button_continue_convert').should('not.have.attr', 'disabled')
+  })
+
+  it('should display 50% of the balance in input field when click on 50% button and when balance after convert is greater than or equal to 0.1 DFI UTXO', function () {
+    cy.getByTestID('50%_amount_button').click()
+    cy.getByTestID('text_input_convert_from_input').should('have.value', '10.00000000')
+  })
+
+  it('should display balance subtracted by 0.1 DFI UTXO in input field when click on MAX button', function () {
+    cy.getByTestID('MAX_amount_button').click()
+    cy.getByTestID('text_input_convert_from_input').should('have.value', '19.90000000')
+    cy.sendDFItoWallet().wait(10000)
+    cy.getByTestID('MAX_amount_button').click()
+    cy.getByTestID('text_input_convert_from_input').should('have.value', '29.90000000')
+  })
+
+  it('should display the same amount in confirm convert screen', function () {
+    cy.getByTestID('button_continue_convert').click()
+    cy.getByTestID('text_convert_amount').contains('29.90000000 DFI (UTXO)')
+  })
+
+  it('should display 0 in input field when UTXO balance is less than or equal to 0.1 DFI UTXO when click on set amount button', function () {
+    cy.createEmptyWallet(true)
+    navigateToConvertScreen()
+    cy.getByTestID('MAX_amount_button').click()
+    cy.getByTestID('text_input_convert_from_input').should('have.value', '0.00000000')
+    cy.getByTestID('50%_amount_button').click()
+    cy.getByTestID('text_input_convert_from_input').should('have.value', '0.00000000')
   })
 })

--- a/cypress/integration/functional/wallet/balances/convert/convert.spec.ts
+++ b/cypress/integration/functional/wallet/balances/convert/convert.spec.ts
@@ -14,12 +14,6 @@ function createDFIWallet (): void {
   cy.getByTestID('convert_button').click()
 }
 
-function navigateToConvertScreen (): void {
-  cy.getByTestID('bottom_tab_balances').click()
-  cy.getByTestID('balances_row_0_utxo').click()
-  cy.getByTestID('convert_button').click()
-}
-
 context('Wallet - Convert DFI', () => {
   before(function () {
     createDFIWallet()
@@ -27,12 +21,12 @@ context('Wallet - Convert DFI', () => {
 
   it('should have form validation', function () {
     cy.getByTestID('button_continue_convert').should('have.attr', 'disabled')
-    cy.getByTestID('source_balance').contains(20)
+    cy.getByTestID('source_balance').contains(19.9)
     cy.getByTestID('target_balance').contains(10)
     cy.getByTestID('text_input_convert_from_input_text').contains('CONVERT UTXO')
     cy.getByTestID('text_input_convert_from_to_text').contains('TO TOKEN')
     cy.getByTestID('text_input_convert_from_input').type('1')
-    cy.getByTestID('source_balance').contains(20)
+    cy.getByTestID('source_balance').contains(19.9)
     cy.getByTestID('target_balance').contains(11)
   })
 
@@ -51,7 +45,18 @@ context('Wallet - Convert DFI', () => {
     cy.go('back')
   })
 
-  it('should test amount buttons', function () {
+  it('should test amount buttons when UTXO to account conversion', function () {
+    cy.getByTestID('button_convert_mode_toggle').click().wait(4000)
+    cy.getByTestID('50%_amount_button').click()
+    cy.getByTestID('text_input_convert_from_input').should('have.value', '9.95000000')
+    cy.getByTestID('target_balance').contains(19.95)
+    cy.getByTestID('MAX_amount_button').click()
+    cy.getByTestID('text_input_convert_from_input').should('have.value', '19.90000000')
+    cy.getByTestID('target_balance').contains(29.9)
+  })
+
+  it('should test amount buttons when account to UTXO conversion', function () {
+    cy.getByTestID('button_convert_mode_toggle').click().wait(4000)
     cy.getByTestID('50%_amount_button').click()
     cy.getByTestID('text_input_convert_from_input').should('have.value', '5.00000000')
     cy.getByTestID('target_balance').contains(25)
@@ -89,7 +94,7 @@ context('Wallet - Convert DFI', () => {
 
     cy.getByTestID('button_continue_convert').click()
     cy.getByTestID('text_convert_amount').contains('1.00000000 DFI (UTXO)')
-    cy.getByTestID('source_amount').contains('19.00000000')
+    cy.getByTestID('source_amount').contains('18.90000000')
     cy.getByTestID('source_amount_unit').contains('UTXO')
     cy.getByTestID('target_amount').contains('11.00000000')
     cy.getByTestID('target_amount_unit').contains('Token')
@@ -133,52 +138,5 @@ context('Wallet - Convert Account to UTXO', function () {
 
     cy.getByTestID('balances_row_0_utxo_amount').contains('20.999')
     cy.getByTestID('balances_row_0_amount').contains('9')
-  })
-})
-
-context('Wallet - Convert UTXO to Account with at least 0.1 UTXO in Balance', function () {
-  before(function () {
-    createDFIWallet()
-  })
-
-  it('should disable continue button if UTXO balance after conversion is less than 0.1 DFI UTXO', function () {
-    cy.getByTestID('text_input_convert_from_input').clear().type('20')
-    cy.getByTestID('button_continue_convert').should('have.attr', 'disabled')
-    cy.getByTestID('text_input_convert_from_input').clear().type('19.90000001')
-    cy.getByTestID('button_continue_convert').should('have.attr', 'disabled')
-  })
-
-  it('should enable continue button if UTXO balance after conversion is greater than or equal to 0.1 DFI UTXO', function () {
-    cy.getByTestID('text_input_convert_from_input').clear().type('19.9')
-    cy.getByTestID('button_continue_convert').should('not.have.attr', 'disabled')
-    cy.getByTestID('text_input_convert_from_input').clear().type('0.00000001')
-    cy.getByTestID('button_continue_convert').should('not.have.attr', 'disabled')
-  })
-
-  it('should display 50% of the balance in input field when click on 50% button and when balance after convert is greater than or equal to 0.1 DFI UTXO', function () {
-    cy.getByTestID('50%_amount_button').click()
-    cy.getByTestID('text_input_convert_from_input').should('have.value', '10.00000000')
-  })
-
-  it('should display balance subtracted by 0.1 DFI UTXO in input field when click on MAX button', function () {
-    cy.getByTestID('MAX_amount_button').click()
-    cy.getByTestID('text_input_convert_from_input').should('have.value', '19.90000000')
-    cy.sendDFItoWallet().wait(10000)
-    cy.getByTestID('MAX_amount_button').click()
-    cy.getByTestID('text_input_convert_from_input').should('have.value', '29.90000000')
-  })
-
-  it('should display the same amount in confirm convert screen', function () {
-    cy.getByTestID('button_continue_convert').click()
-    cy.getByTestID('text_convert_amount').contains('29.90000000 DFI (UTXO)')
-  })
-
-  it('should display 0 in input field when UTXO balance is less than or equal to 0.1 DFI UTXO when click on set amount button', function () {
-    cy.createEmptyWallet(true)
-    navigateToConvertScreen()
-    cy.getByTestID('MAX_amount_button').click()
-    cy.getByTestID('text_input_convert_from_input').should('have.value', '0.00000000')
-    cy.getByTestID('50%_amount_button').click()
-    cy.getByTestID('text_input_convert_from_input').should('have.value', '0.00000000')
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
- To auto deduct 0.1 DFI UTXO if user try to convert all UTXO to Token

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #715 

#### Additional comments?:
- Added condition to block continue button if balance after convert is less than 0.1
- Added condition to set UTXO input amount 0 if user press on 50% or MAX button when UTXO balance is equal or less than 0.1
- Tested on iPhone 12 and pixel 3a emulator