### PR TITLE
disabled poolswap button - remove max amount for token B

### DIFF
--- a/app/screens/AppNavigator/screens/Dex/PoolSwap/PoolSwapScreen.tsx
+++ b/app/screens/AppNavigator/screens/Dex/PoolSwap/PoolSwapScreen.tsx
@@ -190,7 +190,6 @@ export function PoolSwapScreen ({ route }: Props): JSX.Element {
         control={control}
         controlName={tokenBForm}
         isDisabled
-        maxAmount={aToBPrice.times(getValues()[tokenAForm]).toFixed(8)}
         title={`${translate('screens/PoolSwapScreen', 'TO')} ${tokenB.displaySymbol}`}
         token={tokenB}
       />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
Currently, when doing pool swaps on mainnet. There are some cases where "continue" button is disabled. This is due to the fact that we're using a "max amount" for Token B. We have this behavior before because we're allowing input in TokenB (currently, it's disabled). 

There's a slight difference on the calculated amount and max amount causing it to be invalid. Since we're not allowing editing of Token B, we don't need maxAmount for it.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #728 
Fixes #689 

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [x] No console errors on web
- [x] Tested on Light mode and Dark mode*
- [x] Your UI implementation visually matched the rendered design*
- [x] Unit tests*
- [x] Added e2e tests*
- [x] Added translations*

<!-- 
* If applicable 
-->
