### PR TITLE
governance.yml to automate capturing of platform and version labels

### DIFF
--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -124,6 +124,20 @@ issue:
         member: true
         owner: true
 
+  captures:
+    - regex: ' *v(\d+\.\d+\.\d+) *'
+      github_release: true
+      ignore_case: true
+      label: 'version/$CAPTURED'
+
+    - regex: '* iOS *'
+      label: 'platform/ios'
+      ignore_case: true
+
+    - regex: '* Android *'
+      label: 'platform/android'
+      ignore_case: true
+
 pull_request:
   labels:
     - prefix: kind

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -125,16 +125,16 @@ issue:
         owner: true
 
   captures:
-    - regex: ' *v(\d+\.\d+\.\d+) *'
+    - regex: '\W*v?(\d+\.\d+\.\d+)\W*'
       github_release: true
       ignore_case: true
       label: 'version/$CAPTURED'
 
-    - regex: ' *iOS *'
+    - regex: '\W*iOS\W*'
       label: 'platform/ios'
       ignore_case: true
 
-    - regex: ' *Android *'
+    - regex: '\W*Android\W*'
       label: 'platform/android'
       ignore_case: true
 

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -130,11 +130,11 @@ issue:
       ignore_case: true
       label: 'version/$CAPTURED'
 
-    - regex: '* iOS *'
+    - regex: ' *iOS *'
       label: 'platform/ios'
       ignore_case: true
 
-    - regex: '* Android *'
+    - regex: ' *Android *'
       label: 'platform/android'
       ignore_case: true
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -90,6 +90,12 @@
 - color: fbca04
   name: area/settings
 
+# Platform
+- color: 0d1d49
+  name: platform/ios
+- color: 0d1d49
+  name: platform/android
+
 # Priority
 - color: d93f0b
   name: priority/urgent-now


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

OSS Governance Bot has the ability to automatically regex capture version and platform from issue conversations. 

The Version label will be captured from /releases hence only released builds will show up with a new label.
