### PR TITLE
Wait for Privacy lock and Storage to load

### DIFF
--- a/mobile-app/app/contexts/LocalAuthContext.tsx
+++ b/mobile-app/app/contexts/LocalAuthContext.tsx
@@ -36,6 +36,8 @@ export function PrivacyLockContextProvider (props: React.PropsWithChildren<any>)
   const [isDeviceProtected, setIsDeviceProtected] = useState<boolean>(false)
   const [isPrivacyLock, setIsPrivacyLock] = useState<boolean>()
   const [isAuthenticating, setIsAuthenticating] = useState<boolean>(false)
+  const [isLocalAuthLoaded, setIsLocalAuthLoaded] = useState<boolean>(false)
+  const [isDevicePersistenceLoaded, setIsDevicePersistenceLoaded] = useState<boolean>(false)
 
   const fetchHardwareStatus = (): void => {
     LocalAuthentication.hasHardwareAsync()
@@ -49,10 +51,12 @@ export function PrivacyLockContextProvider (props: React.PropsWithChildren<any>)
         setBiometricHardwares(await LocalAuthentication.supportedAuthenticationTypesAsync())
         setIsDeviceProtected(security !== SecurityLevel.NONE)
         setHasHardware(hasHardware) // last, also used as flag indicated hardware check completed
+        setIsLocalAuthLoaded(true)
       })
       .catch(error => {
         Logging.error(error)
         setHasHardware(false)
+        setIsLocalAuthLoaded(true)
       })
   }
 
@@ -63,6 +67,9 @@ export function PrivacyLockContextProvider (props: React.PropsWithChildren<any>)
       .catch(error => {
         Logging.error(error)
         setIsPrivacyLock(false)
+      })
+      .finally(() => {
+        setIsDevicePersistenceLoaded(true)
       })
   }, [/* only load from persistence layer once */])
 
@@ -125,7 +132,7 @@ export function PrivacyLockContextProvider (props: React.PropsWithChildren<any>)
     }
   }
 
-  if (isPrivacyLock === undefined) {
+  if (isPrivacyLock === undefined || !(isLocalAuthLoaded && isDevicePersistenceLoaded)) {
     return null
   }
   return (

--- a/mobile-app/app/screens/PrivacyLock.tsx
+++ b/mobile-app/app/screens/PrivacyLock.tsx
@@ -49,7 +49,9 @@ export function PrivacyLock (): JSX.Element {
   // this run only ONCE on fresh start
   // isPrivacyLock change in-app should not re-triggered
   useEffect(() => {
-    authenticateOrExit(privacyLock)
+    if (privacyLock.isEnabled) {
+      authenticateOrExit(privacyLock)
+    }
   }, [])
 
   if (privacyLock.isAuthenticating || APP_LAST_ACTIVE.force) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
Currently, local storage setting (Privacy Toggle) and Hardware Async are checked before we display the prompt. This fix waits for the two promises before displaying the contents. Needs to be fully tested on a standalone device.
#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
