### PR TITLE
removed .idea/inspectionProfiles

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
-  </profile>
-</component>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

We should remove the eslint inspection profile on IDE. I personally think the eslint running on live mode is quite distracting to development seeing those errors. Most of the errors that are shown in the IntelliSense are usually always corrected when we commit due to lint-staged. On slower computers, it's just perhaps too expensive to run this operation concurrently when writing code.
