### PR TITLE
`error message` - fallback to display message from API

### DIFF
--- a/mobile-app/app/components/OceanInterface/TransactionError.tsx
+++ b/mobile-app/app/components/OceanInterface/TransactionError.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { View } from 'react-native'
 import { translate } from '@translations'
 import { tailwind } from '@tailwind'
-import { ThemedIcon, ThemedText } from '@components/themed'
+import { ThemedIcon, ThemedScrollView, ThemedText } from '@components/themed'
 import { TransactionCloseButton } from './TransactionCloseButton'
 
 interface TransactionErrorProps {
@@ -43,7 +42,14 @@ export function TransactionError ({
         size={20}
       />
 
-      <View style={tailwind('flex-auto mx-3 justify-center')}>
+      <ThemedScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={tailwind('justify-center flex flex-col')}
+        light={tailwind('bg-white')}
+        dark={tailwind('bg-gray-800')}
+        style={tailwind('mx-3')}
+      >
         <ThemedText
           style={tailwind('text-sm font-bold')}
         >
@@ -57,7 +63,7 @@ export function TransactionError ({
         >
           {translate('screens/OceanInterface', err.message)}
         </ThemedText>
-      </View>
+      </ThemedScrollView>
 
       <TransactionCloseButton onPress={onClose} />
     </>
@@ -114,6 +120,15 @@ function errorMessageMapping (err: string): ErrorMapping {
 
   return {
     code: ErrorCodes.UnknownError,
-    message: err
+    message: getErrorMessage(err)
   }
+}
+
+function getErrorMessage (err: string): string {
+  const errParts = err.split(':')
+  if (errParts.length !== 4) {
+    return err
+  }
+
+  return errParts[2].concat(errParts[3]).trim() // display error message without HTTP error code and url path
 }

--- a/mobile-app/app/components/OceanInterface/TransactionError.tsx
+++ b/mobile-app/app/components/OceanInterface/TransactionError.tsx
@@ -125,10 +125,10 @@ function errorMessageMapping (err: string): ErrorMapping {
 }
 
 function getErrorMessage (err: string): string {
-  const errParts = err.split(':')
+  const errParts = err?.split(':')
   if (errParts.length !== 4) {
     return err
   }
 
-  return errParts[2].concat(errParts[3]).trim() // display error message without HTTP error code and url path
+  return errParts[2]?.concat(errParts[3])?.trim() // display error message without HTTP error code and url path
 }

--- a/mobile-app/cypress/integration/functional/wallet/balances/send.spec.ts
+++ b/mobile-app/cypress/integration/functional/wallet/balances/send.spec.ts
@@ -350,6 +350,7 @@ context('Wallet - Send - Switch token', function () {
     cy.getByTestID('select_DFI_value').should('have.text', '20.00000000')
     cy.getByTestID('select_dBTC_value').should('have.text', '10.00000000')
     cy.getByTestID('select_dETH_value').should('have.text', '10.00000000')
+    cy.wait(3000) // timeout to allow max. one block-cycle of re-render
     cy.getByTestID('select_DFI').click()
     cy.getByTestID('selected_token').should('have.text', 'DFI')
     cy.getByTestID('max_value').contains('DFI')


### PR DESCRIPTION
Temporarily use scroll view to see full message, will update when design is ready

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
- To display clearer error message to the user for un-mapped error message

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1612 

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [x] No console errors on web
- [x] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
