### PR TITLE
Hide BURN-DFI pool pair from pool pair listing

### DIFF
--- a/mobile-app/cypress/integration/smoke/smoke.spec.ts
+++ b/mobile-app/cypress/integration/smoke/smoke.spec.ts
@@ -174,7 +174,7 @@ context('Mainnet - Wallet - Pool Pair Values', () => {
   it('should verify poolpair values', function () {
     cy.getByTestID('dex_tabs_AVAILABLE_POOL_PAIRS').click()
     cy.wrap<DexItem[]>(whale.poolpairs.list(50), { timeout: 20000 }).then((pairs) => {
-      const available: PoolPairData[] = pairs.map(data => ({ type: 'available', data: data }))
+      const available: PoolPairData[] = pairs.filter(pair => pair.symbol !== 'BURN-DFI').map(data => ({ type: 'available', data: data }))
       cy.wait(5000)
       cy.getByTestID('available_liquidity_tab').scrollTo('bottom')
       available.forEach((pair, index) => {

--- a/shared/store/wallet.ts
+++ b/shared/store/wallet.ts
@@ -78,7 +78,7 @@ export const fetchPoolPairs = createAsyncThunk(
   'wallet/fetchPoolPairs',
   async ({ size = 200, client }: { size?: number, client: WhaleApiClient }): Promise<DexItem[]> => {
     const pairs = await client.poolpairs.list(size)
-    return pairs.map(data => ({ type: 'available', data }))
+    return pairs.filter(pair => pair.symbol !== 'BURN-DFI').map(data => ({ type: 'available', data }))
   }
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
This PR hides the `dBURN-DFI` pair on DEX tab. This pair was created as part of the fix for the dBTC exploit
#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
