### PR TITLE
feature(ui-ux): add DFI price on balances page (#2286)

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Balances/components/DFIBalanceCard.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Balances/components/DFIBalanceCard.tsx
@@ -29,6 +29,7 @@ export function DFIBalanceCard (): JSX.Element {
   const { hasFetchedToken } = useSelector((state: RootState) => state.wallet)
   const { getTokenPrice } = useTokenPrice()
   const { isBalancesDisplayed } = useDisplayBalancesContext()
+  const dfiPriceInUsd = getTokenPrice(DFIUnified.symbol, new BigNumber(1), DFIUnified.isLPS)
   const usdAmount = getTokenPrice(DFIUnified.symbol, new BigNumber(DFIUnified.amount), DFIUnified.isLPS)
   const DFIIcon = getNativeIcon('_UTXO')
   const { isLight } = useThemeContext()
@@ -55,7 +56,7 @@ export function DFIBalanceCard (): JSX.Element {
           >
             <View style={tailwind('flex-row items-center')}>
               <DFIIcon width={32} height={32} />
-              <TokenNameText displaySymbol='DFI' name='DeFiChain' testID='total_dfi_label' />
+              <TokenNameText displaySymbol={'DFI ($' + dfiPriceInUsd.toFixed(2).toString() + ')'} name='DeFiChain' testID='total_dfi_label' />
             </View>
 
             {


### PR DESCRIPTION
#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:
Adding the DFI price to the DFIBalanceCard which is shown on the balances page.

#### Which issue(s) does this PR fixes?:
Fixes #2286

#### Additional comments?:

#### Developer Checklist:
- [ x] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [x ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

