### PR TITLE
welcome screen - display app version #2703

### DIFF
--- a/mobile-app/app/components/VersionText.tsx
+++ b/mobile-app/app/components/VersionText.tsx
@@ -1,0 +1,15 @@
+import { tailwind } from '@tailwind'
+import { nativeApplicationVersion } from 'expo-application'
+import { ThemedText } from '@components/themed'
+
+export function VersionText (): JSX.Element {
+  return (
+    <ThemedText
+      dark={tailwind('text-gray-400 border-gray-400')}
+      light={tailwind('text-gray-500 border-gray-500')}
+      style={tailwind('text-sm font-medium mt-1 border rounded py-0.5 px-1.5')}
+    >
+      {`Version ${nativeApplicationVersion ?? '0.0.0'}`}
+    </ThemedText>
+  )
+}

--- a/mobile-app/app/screens/AppNavigator/screens/Settings/screens/AboutScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Settings/screens/AboutScreen.tsx
@@ -121,8 +121,12 @@ export function AboutScreen (): JSX.Element {
           {translate('screens/AboutScreen', 'DeFiChain Wallet')}
         </ThemedText>
 
-        <ThemedText style={tailwind('text-base font-light text-black')}>
-          {`v${nativeApplicationVersion ?? '0.0.0'}`}
+        <ThemedText
+          dark={tailwind('text-gray-400 border-gray-400')}
+          light={tailwind('text-gray-500 border-gray-500')}
+          style={tailwind('text-sm font-medium mt-1 border rounded py-0.5 px-1.5')}
+        >
+          {`Version ${nativeApplicationVersion ?? '0.0.0'}`}
         </ThemedText>
 
         {hasBetaFeatures && (

--- a/mobile-app/app/screens/AppNavigator/screens/Settings/screens/AboutScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Settings/screens/AboutScreen.tsx
@@ -1,5 +1,4 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons'
-import { nativeApplicationVersion } from 'expo-application'
 
 import { TouchableOpacity, View } from 'react-native'
 import { AppIcon } from '@components/icons/AppIcon'
@@ -10,6 +9,7 @@ import { NavigationProp, useNavigation } from '@react-navigation/native'
 import { openURL } from '@api/linking'
 import { SettingsParamList } from '../SettingsNavigator'
 import { useFeatureFlagContext } from '@contexts/FeatureFlagContext'
+import { VersionText } from '@components/VersionText'
 
 interface AboutScreenLinks {
   testID: string
@@ -121,13 +121,7 @@ export function AboutScreen (): JSX.Element {
           {translate('screens/AboutScreen', 'DeFiChain Wallet')}
         </ThemedText>
 
-        <ThemedText
-          dark={tailwind('text-gray-400 border-gray-400')}
-          light={tailwind('text-gray-500 border-gray-500')}
-          style={tailwind('text-sm font-medium mt-1 border rounded py-0.5 px-1.5')}
-        >
-          {`Version ${nativeApplicationVersion ?? '0.0.0'}`}
-        </ThemedText>
+        <VersionText />
 
         {hasBetaFeatures && (
           <TouchableOpacity

--- a/mobile-app/app/screens/WalletNavigator/screens/components/OnboardingCarousel.tsx
+++ b/mobile-app/app/screens/WalletNavigator/screens/components/OnboardingCarousel.tsx
@@ -9,6 +9,7 @@ import { ThemedText } from '@components/themed'
 import { useThemeContext } from '@shared-contexts/ThemeProvider'
 import { tailwind } from '@tailwind'
 import { translate } from '@translations'
+import { nativeApplicationVersion } from 'expo-application'
 
 interface CarouselImage {
   image: ImageSourcePropType
@@ -61,6 +62,14 @@ export function InitialSlide (): JSX.Element {
         style={tailwind('text-base font-medium mt-1')}
       >
         {translate('screens/OnboardingCarousel', 'Native DeFi for Bitcoin')}
+      </ThemedText>
+
+      <ThemedText
+        dark={tailwind('text-gray-400')}
+        light={tailwind('text-gray-500')}
+        style={tailwind('text-sm font-medium mt-1')}
+      >
+        {`Version ${nativeApplicationVersion ?? '0.0.0'}`}
       </ThemedText>
     </View>
   )

--- a/mobile-app/app/screens/WalletNavigator/screens/components/OnboardingCarousel.tsx
+++ b/mobile-app/app/screens/WalletNavigator/screens/components/OnboardingCarousel.tsx
@@ -9,7 +9,7 @@ import { ThemedText } from '@components/themed'
 import { useThemeContext } from '@shared-contexts/ThemeProvider'
 import { tailwind } from '@tailwind'
 import { translate } from '@translations'
-import { nativeApplicationVersion } from 'expo-application'
+import { VersionText } from '@components/VersionText'
 
 interface CarouselImage {
   image: ImageSourcePropType
@@ -64,13 +64,7 @@ export function InitialSlide (): JSX.Element {
         {translate('screens/OnboardingCarousel', 'Native DeFi for Bitcoin')}
       </ThemedText>
 
-      <ThemedText
-        dark={tailwind('text-gray-400 border-gray-400')}
-        light={tailwind('text-gray-500 border-gray-500')}
-        style={tailwind('text-sm font-medium mt-1 border rounded py-0.5 px-1.5')}
-      >
-        {`Version ${nativeApplicationVersion ?? '0.0.0'}`}
-      </ThemedText>
+      <VersionText />
     </View>
   )
 }

--- a/mobile-app/app/screens/WalletNavigator/screens/components/OnboardingCarousel.tsx
+++ b/mobile-app/app/screens/WalletNavigator/screens/components/OnboardingCarousel.tsx
@@ -65,9 +65,9 @@ export function InitialSlide (): JSX.Element {
       </ThemedText>
 
       <ThemedText
-        dark={tailwind('text-gray-400')}
-        light={tailwind('text-gray-500')}
-        style={tailwind('text-sm font-medium mt-1')}
+        dark={tailwind('text-gray-400 border-gray-400')}
+        light={tailwind('text-gray-500 border-gray-500')}
+        style={tailwind('text-sm font-medium mt-1 border rounded py-0.5 px-1.5')}
       >
         {`Version ${nativeApplicationVersion ?? '0.0.0'}`}
       </ThemedText>


### PR DESCRIPTION
#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:
Display app version on welcome screen. Currently, there's no way to determine the app version if you're not on wallet context (e.g, About Screen)

#### Which issue(s) does this PR fixes?:
Fixes #2703