### PR TITLE
token detail - reenable for DFI #2395

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Balances/components/DFIBalanceCard.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Balances/components/DFIBalanceCard.tsx
@@ -58,6 +58,7 @@ export function DFIBalanceCard ({ denominationCurrency }: DFIBalaceCardProps): J
           params: { token: DFIUnified },
           merge: true
         })}
+        testID='dfi_balance_card_touchable'
       >
         <View style={tailwind('flex-col flex-1')}>
           <ImageBackground

--- a/mobile-app/app/screens/AppNavigator/screens/Balances/components/DFIBalanceCard.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Balances/components/DFIBalanceCard.tsx
@@ -7,7 +7,7 @@ import { ImageBackground } from 'react-native'
 import DFIBackground from '@assets/images/DFI_balance_bg_gradient.png'
 import DFIBackgroundDark from '@assets/images/DFI_balance_bg_gradient_dark.png'
 import { IconButton } from '@components/IconButton'
-import { ThemedView } from '@components/themed'
+import { ThemedView, ThemedTouchableOpacity } from '@components/themed'
 import { View } from '@components'
 import { getNativeIcon } from '@components/icons/assets'
 import { useSelector } from 'react-redux'
@@ -28,6 +28,7 @@ interface DFIBalaceCardProps {
 }
 
 export function DFIBalanceCard ({ denominationCurrency }: DFIBalaceCardProps): JSX.Element {
+  const navigation = useNavigation<NavigationProp<BalanceParamList>>()
   const DFIToken = useSelector((state: RootState) => DFITokenSelector(state.wallet))
   const DFIUtxo = useSelector((state: RootState) => DFIUtxoSelector(state.wallet))
   const DFIUnified = useSelector((state: RootState) => unifiedDFISelector(state.wallet))
@@ -51,91 +52,99 @@ export function DFIBalanceCard ({ denominationCurrency }: DFIBalaceCardProps): J
       style={tailwind('mx-4 mb-1.5 rounded-lg flex-1')}
       testID='dfi_balance_card'
     >
-      <View style={tailwind('flex-col flex-1')}>
-        <ImageBackground
-          source={isLight ? DFIBackground : DFIBackgroundDark}
-          style={tailwind('flex-1 rounded-lg overflow-hidden')}
-          resizeMode='cover'
-          resizeMethod='scale'
-        >
-          <View style={tailwind('flex-row m-4 mb-2 justify-between')}>
-            <View style={tailwind('flex-row items-center')}>
-              <DFIIcon width={32} height={32} />
-              <TokenNameText displaySymbol='DFI' name='DeFiChain' testID='total_dfi_label' />
-            </View>
-
-            {
-              hasFetchedToken
-                ? (
-                  <TokenAmountText
-                    tokenAmount={lockedToken.amount.plus(DFIUnified.amount).toFixed(8)}
-                    usdAmount={usdAmount}
-                    testID='dfi_total_balance'
-                    isBalancesDisplayed={isBalancesDisplayed}
-                    denominationCurrency={denominationCurrency}
-                  />
-                )
-                : (
-                  <View style={tailwind('pt-1')}>
-                    <View style={tailwind('mb-1.5')}>
-                      <TextSkeletonLoader
-                        iContentLoaderProps={{
-                          width: '150',
-                          height: '16',
-                          testID: 'dfi_balance_skeleton_loader'
-                        }}
-                        textHorizontalOffset='30'
-                        textWidth='120'
-                      />
-                    </View>
-                    <View>
-                      <TextSkeletonLoader
-                        iContentLoaderProps={{
-                          width: '150',
-                          height: '12',
-                          testID: 'dfi_USD_balance_skeleton_loader'
-                        }}
-                        textHorizontalOffset='30'
-                        textWidth='120'
-                      />
-                    </View>
-                  </View>
-                )
-            }
-          </View>
-          <View style={tailwind('mx-4')}>
-            <TokenBreakdownPercentage
-              symbol='DFI'
-              availableAmount={new BigNumber(DFIUnified.amount)}
-              onBreakdownPress={onBreakdownPress}
-              isBreakdownExpanded={isBreakdownExpanded}
-              lockedAmount={lockedToken.amount}
-              testID='dfi'
-            />
-          </View>
-        </ImageBackground>
-
-        {isBreakdownExpanded && (
-          <ThemedView
-            light={tailwind('border-t border-gray-100')}
-            dark={tailwind('border-t border-gray-700')}
-            style={tailwind('mx-4 mb-4 pt-2')}
+      <ThemedTouchableOpacity
+        onPress={() => navigation.navigate({
+          name: 'TokenDetail',
+          params: { token: DFIUnified },
+          merge: true
+        })}
+      >
+        <View style={tailwind('flex-col flex-1')}>
+          <ImageBackground
+            source={isLight ? DFIBackground : DFIBackgroundDark}
+            style={tailwind('flex-1 rounded-lg overflow-hidden')}
+            resizeMode='cover'
+            resizeMethod='scale'
           >
-            <TokenBreakdownDetails
-              hasFetchedToken={hasFetchedToken}
-              lockedAmount={lockedToken.amount}
-              lockedValue={lockedToken.tokenValue}
-              availableAmount={new BigNumber(DFIUnified.amount)}
-              availableValue={availableValue}
-              testID='dfi'
-              dfiUtxo={DFIUtxo}
-              dfiToken={DFIToken}
-              denominationCurrency={denominationCurrency}
-            />
-            <DFIBreakdownAction dfiUnified={DFIUnified} />
-          </ThemedView>
-        )}
-      </View>
+            <View style={tailwind('flex-row m-4 mb-2 justify-between')}>
+              <View style={tailwind('flex-row items-center')}>
+                <DFIIcon width={32} height={32} />
+                <TokenNameText displaySymbol='DFI' name='DeFiChain' testID='total_dfi_label' />
+              </View>
+
+              {
+                hasFetchedToken
+                  ? (
+                    <TokenAmountText
+                      tokenAmount={lockedToken.amount.plus(DFIUnified.amount).toFixed(8)}
+                      usdAmount={usdAmount}
+                      testID='dfi_total_balance'
+                      isBalancesDisplayed={isBalancesDisplayed}
+                      denominationCurrency={denominationCurrency}
+                    />
+                  )
+                  : (
+                    <View style={tailwind('pt-1')}>
+                      <View style={tailwind('mb-1.5')}>
+                        <TextSkeletonLoader
+                          iContentLoaderProps={{
+                            width: '150',
+                            height: '16',
+                            testID: 'dfi_balance_skeleton_loader'
+                          }}
+                          textHorizontalOffset='30'
+                          textWidth='120'
+                        />
+                      </View>
+                      <View>
+                        <TextSkeletonLoader
+                          iContentLoaderProps={{
+                            width: '150',
+                            height: '12',
+                            testID: 'dfi_USD_balance_skeleton_loader'
+                          }}
+                          textHorizontalOffset='30'
+                          textWidth='120'
+                        />
+                      </View>
+                    </View>
+                  )
+              }
+            </View>
+            <View style={tailwind('mx-4')}>
+              <TokenBreakdownPercentage
+                symbol='DFI'
+                availableAmount={new BigNumber(DFIUnified.amount)}
+                onBreakdownPress={onBreakdownPress}
+                isBreakdownExpanded={isBreakdownExpanded}
+                lockedAmount={lockedToken.amount}
+                testID='dfi'
+              />
+            </View>
+          </ImageBackground>
+
+          {isBreakdownExpanded && (
+            <ThemedView
+              light={tailwind('border-t border-gray-100')}
+              dark={tailwind('border-t border-gray-700')}
+              style={tailwind('mx-4 mb-4 pt-2')}
+            >
+              <TokenBreakdownDetails
+                hasFetchedToken={hasFetchedToken}
+                lockedAmount={lockedToken.amount}
+                lockedValue={lockedToken.tokenValue}
+                availableAmount={new BigNumber(DFIUnified.amount)}
+                availableValue={availableValue}
+                testID='dfi'
+                dfiUtxo={DFIUtxo}
+                dfiToken={DFIToken}
+                denominationCurrency={denominationCurrency}
+              />
+              <DFIBreakdownAction dfiUnified={DFIUnified} />
+            </ThemedView>
+          )}
+        </View>
+      </ThemedTouchableOpacity>
     </ThemedView>
   )
 }

--- a/mobile-app/app/screens/AppNavigator/screens/Balances/screens/TokenDetailScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Balances/screens/TokenDetailScreen.tsx
@@ -7,7 +7,7 @@ import NumberFormat from 'react-number-format'
 import { StackScreenProps } from '@react-navigation/stack'
 import { MaterialIcons } from '@expo/vector-icons'
 import { translate } from '@translations'
-import { fetchTokens, tokensSelector, WalletToken } from '@store/wallet'
+import { fetchTokens, tokensSelector, WalletToken, unifiedDFISelector } from '@store/wallet'
 import { useDeFiScanContext } from '@shared-contexts/DeFiScanContext'
 import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { View } from '@components'
@@ -93,6 +93,7 @@ const usePoolPairToken = (tokenParam: WalletToken): { pair?: PoolPairData, token
 }
 
 export function TokenDetailScreen ({ route, navigation }: Props): JSX.Element {
+  const DFIUnified = useSelector((state: RootState) => unifiedDFISelector(state.wallet))
   const { pair, token, swapTokenDisplaySymbol } = usePoolPairToken(route.params.token)
   const onNavigateLiquidity = ({ destination, pair }: { destination: 'AddLiquidity' | 'RemoveLiquidity', pair: PoolPairData }): void => {
     navigation.navigate('DEX', {
@@ -121,6 +122,17 @@ export function TokenDetailScreen ({ route, navigation }: Props): JSX.Element {
             isPreselected: false
           }
         }
+      },
+      merge: true
+    })
+  }
+
+  const onNavigateSwapDfi = (): void => {
+    navigation.navigate(translate('BottomTabNavigator', 'Balances'), {
+      screen: 'CompositeSwap',
+      initial: false,
+      params: {
+        fromToken: DFIUnified
       },
       merge: true
     })
@@ -173,6 +185,17 @@ export function TokenDetailScreen ({ route, navigation }: Props): JSX.Element {
             testID='convert_button'
             title={`${translate('screens/TokenDetailScreen', 'Convert to {{symbol}}', { symbol: `${token.id === '0_utxo' ? 'Token' : 'UTXO'}` })}`}
           />
+        )
+      }
+
+      {
+        token.symbol === 'DFI' && (
+          <TokenActionRow
+             icon='swap-horiz'
+             onPress={() => onNavigateSwapDfi()}
+             testID='swap_button'
+             title={translate('screens/TokenDetailScreen', 'Swap token')}
+           />
         )
       }
 

--- a/mobile-app/app/screens/AppNavigator/screens/Balances/screens/TokenDetailScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Balances/screens/TokenDetailScreen.tsx
@@ -191,11 +191,11 @@ export function TokenDetailScreen ({ route, navigation }: Props): JSX.Element {
       {
         token.symbol === 'DFI' && (
           <TokenActionRow
-             icon='swap-horiz'
-             onPress={() => onNavigateSwapDfi()}
-             testID='swap_button_dfi'
-             title={translate('screens/TokenDetailScreen', 'Swap token')}
-           />
+            icon='swap-horiz'
+            onPress={() => onNavigateSwapDfi()}
+            testID='swap_button_dfi'
+            title={translate('screens/TokenDetailScreen', 'Swap token')}
+          />
         )
       }
 

--- a/mobile-app/app/screens/AppNavigator/screens/Balances/screens/TokenDetailScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Balances/screens/TokenDetailScreen.tsx
@@ -193,7 +193,7 @@ export function TokenDetailScreen ({ route, navigation }: Props): JSX.Element {
           <TokenActionRow
              icon='swap-horiz'
              onPress={() => onNavigateSwapDfi()}
-             testID='swap_button'
+             testID='swap_button_dfi'
              title={translate('screens/TokenDetailScreen', 'Swap token')}
            />
         )

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreen.tsx
@@ -215,6 +215,23 @@ export function CompositeSwapScreen ({ route }: Props): JSX.Element {
   }, [])
 
   useEffect(() => {
+    if (route.params.fromToken !== undefined) {
+      setIsFromTokenSelectDisabled(true)
+      setIsToTokenSelectDisabled(false)
+      onTokenSelect({
+        tokenId: route.params.fromToken.id,
+        available: new BigNumber(route.params.fromToken.amount),
+        token: {
+          displaySymbol: route.params.fromToken.displaySymbol,
+          symbol: route.params.fromToken.symbol,
+          name: route.params.fromToken.name
+        },
+        reserve: route.params.fromToken.amount
+      }, 'FROM')
+
+      return
+    }
+
     if (route.params.pair?.id === undefined) {
       return
     }
@@ -261,7 +278,7 @@ export function CompositeSwapScreen ({ route }: Props): JSX.Element {
         reserve: pair.data.tokenB.reserve
       }, 'TO')
     }
-  }, [route.params.pair, route.params.tokenSelectOption])
+  }, [route.params.pair, route.params.tokenSelectOption, route.params.fromToken])
 
   useEffect(() => {
     void getSelectedPoolPairs()

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/DexNavigator.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/DexNavigator.tsx
@@ -20,6 +20,7 @@ export interface DexParamList {
   DexScreen: undefined
   CompositeSwapScreen: {
     pair?: PoolPairData
+    fromToken?: WalletToken
     tokenSelectOption?: {
       from: {
         isDisabled: boolean

--- a/mobile-app/cypress/integration/functional/wallet/balances/tokenDetail.spec.ts
+++ b/mobile-app/cypress/integration/functional/wallet/balances/tokenDetail.spec.ts
@@ -91,3 +91,38 @@ context('Wallet - Token Detail Defiscan redirection', () => {
     cy.getByTestID('token_detail_explorer_url').should('exist')
   })
 })
+
+context('Wallet - Token Detail - DFI', () => {
+  beforeEach(function () {
+    cy.createEmptyWallet(true)
+    cy.getByTestID('header_settings').click()
+    cy.sendDFItoWallet()
+      .sendDFITokentoWallet()
+      .wait(10000)
+    cy.getByTestID('bottom_tab_balances').click()
+    cy.getByTestID('balances_list').should('exist')
+    cy.getByTestID('dfi_balance_card_touchable').should('exist')
+    cy.getByTestID('dfi_balance_card_touchable').click()
+  })
+
+  it('should be able to click token DFI', function () {
+    cy.getByTestID('token_detail_amount').contains(20)
+    cy.getByTestID('send_button').should('exist')
+    cy.getByTestID('receive_button').should('exist')
+    cy.getByTestID('convert_button').should('exist')
+    cy.getByTestID('swap_button_dfi').should('exist')
+    cy.getByTestID('swap_button').should('not.exist')
+    cy.getByTestID('add_liquidity_button').should('not.exist')
+    cy.getByTestID('remove_liquidity_button').should('not.exist')
+  })
+
+  it('should be able to redirect with Swap', function () {
+    cy.getByTestID('swap_button_dfi').should('exist')
+    cy.getByTestID('swap_button_dfi').click()
+    cy.url().should('include', 'app/CompositeSwap')
+    cy.getByTestID('token_select_button_FROM').should('have.attr', 'aria-disabled')
+    cy.getByTestID('token_select_button_TO').should('not.have.attr', 'aria-disabled')
+    cy.getByTestID('token_select_button_FROM').should('contain', 'DFI')
+    cy.getByTestID('token_select_button_TO').should('contain', 'Select token')
+  })
+})


### PR DESCRIPTION
#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:
Reenable showing Token Detail page when clicking on DFI on the Portfolio page

#### Which issue(s) does this PR fixes?:
Fixes #2395

#### Additional comments?:
This is my first sketch for enabling the Swap token option for DFI in the TokenDetail screen.
@thedoublejay please give your opinion.