### PR TITLE
feature(ui-ux): added expand btn to expand error text in ocean interface

### DIFF
--- a/mobile-app/app/components/OceanInterface/OceanInterface.tsx
+++ b/mobile-app/app/components/OceanInterface/OceanInterface.tsx
@@ -166,7 +166,7 @@ export function OceanInterface (): JSX.Element | null {
     <Animated.View
       style={[tailwind('px-5 py-3 flex-row absolute w-full items-center z-10', currentTheme), {
         bottom: slideAnim,
-        height: 75
+        minHeight: 75
       }]}
     >
       {

--- a/mobile-app/app/components/OceanInterface/TransactionError.tsx
+++ b/mobile-app/app/components/OceanInterface/TransactionError.tsx
@@ -1,9 +1,11 @@
 
+import { useState, useEffect, useCallback } from 'react'
 import { translate } from '@translations'
 import { tailwind } from '@tailwind'
-import { ThemedIcon, ThemedScrollView, ThemedText } from '@components/themed'
+import { ThemedIcon, ThemedText, ThemedView } from '@components/themed'
 import { TransactionCloseButton } from './TransactionCloseButton'
 import { useLogger } from '@shared-contexts/NativeLoggingProvider'
+import { View, TouchableOpacity, Platform } from 'react-native'
 
 interface TransactionErrorProps {
   errMsg: string
@@ -29,43 +31,82 @@ export interface ErrorMapping {
 
 export function TransactionError ({ errMsg, onClose }: TransactionErrorProps): JSX.Element {
   const logger = useLogger()
-  logger.error(`transaction error: ${errMsg}`)
+  const [expand, setExpand] = useState(false)
+  const [canExpand, setCanExpand] = useState(false)
+  const numberOfLines = 1
+
+  useEffect(() => {
+    logger.error(`transaction error: ${errMsg}`)
+  }, [errMsg])
+
+  const getNumberOfLines = (): number => {
+    if (Platform.OS === 'web') {
+      return numberOfLines
+    }
+    return (canExpand && !expand) && numberOfLines
+  }
+
   const err = errorMessageMapping(errMsg)
+
+  const onTextLayout = useCallback(e => {
+    if (e.nativeEvent.lines.length > numberOfLines) {
+      setCanExpand(true)
+    }
+  }, [])
+
   return (
-    <>
+    <View
+      style={tailwind('flex-row items-center justify-center w-full')}
+    >
       <ThemedIcon
+        style={tailwind('w-1/12')}
         dark={tailwind('text-darkerror-500')}
         iconType='MaterialIcons'
         light={tailwind('text-error-500')}
         name='error'
         size={20}
       />
-
-      <ThemedScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={tailwind('justify-center flex flex-col')}
+      <ThemedView
+        style={tailwind('flex flex-col justify-center w-9/12 ml-1')}
         light={tailwind('bg-white')}
         dark={tailwind('bg-gray-800')}
-        style={tailwind('mx-3')}
       >
-        <ThemedText
-          style={tailwind('text-sm font-bold')}
-        >
-          {translate('screens/OceanInterface', `Error Code: ${err.code}`)}
-        </ThemedText>
+        <View style={tailwind('flex flex-row items-center')}>
+          <ThemedText
+            style={tailwind('text-sm font-bold')}
+          >
+            {translate('screens/OceanInterface', `Error Code: ${err.code}`)}
+          </ThemedText>
+          {canExpand && (
+            <TouchableOpacity
+              onPress={() => setExpand(!expand)}
+              testID='details_dfi'
+            >
+              <ThemedIcon
+                light={tailwind('text-gray-600')}
+                dark={tailwind('text-gray-300')}
+                style={tailwind('font-bold')}
+                iconType='MaterialIcons'
+                name={!expand ? 'expand-more' : 'expand-less'}
+                size={24}
+              />
+            </TouchableOpacity>
+          )}
+
+        </View>
 
         <ThemedText
           ellipsizeMode='tail'
-          numberOfLines={1}
+          numberOfLines={getNumberOfLines()}
+          onTextLayout={onTextLayout}
           style={tailwind('text-sm font-bold')}
         >
           {translate('screens/OceanInterface', err.message)}
         </ThemedText>
-      </ThemedScrollView>
+      </ThemedView>
 
       <TransactionCloseButton onPress={onClose} />
-    </>
+    </View>
   )
 }
 

--- a/mobile-app/app/components/OceanInterface/TransactionError.tsx
+++ b/mobile-app/app/components/OceanInterface/TransactionError.tsx
@@ -43,7 +43,7 @@ export function TransactionError ({ errMsg, onClose }: TransactionErrorProps): J
     if (Platform.OS === 'web') {
       return numberOfLines
     }
-    return (canExpand && !expand) && numberOfLines
+    return (canExpand && !expand) ? numberOfLines : 0
   }
 
   const err = errorMessageMapping(errMsg)

--- a/mobile-app/app/components/OceanInterface/__snapshots__/TransactionError.test.tsx.snap
+++ b/mobile-app/app/components/OceanInterface/__snapshots__/TransactionError.test.tsx.snap
@@ -1,7 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`info text should match snapshot for error At least 50% of the vault must be in DFI when taking a loan 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -12,7 +21,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -27,22 +38,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -50,7 +55,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -76,35 +89,36 @@ Array [
       >
         Error Code: 4
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        Insufficient DFI collateral (≥50%)
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      Insufficient DFI collateral (≥50%)
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -168,12 +182,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error Cannot payback loan while any of the asset's price is invalid 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -184,7 +207,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -199,22 +224,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -222,7 +241,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -248,35 +275,36 @@ Array [
       >
         Error Code: 6
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        Cannot payback loan due to invalid price
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      Cannot payback loan due to invalid price
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -340,12 +368,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error Error: Not found, code: 404, message: Page not found 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -356,7 +393,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -371,22 +410,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -394,7 +427,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -420,35 +461,36 @@ Array [
       >
         Error Code: 0
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        404, message Page not found
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      404, message Page not found
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -512,12 +554,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error Lack of liquidity 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -528,7 +579,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -543,22 +596,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -566,7 +613,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -592,35 +647,36 @@ Array [
       >
         Error Code: 5
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        Pool does not have enough liquidity
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      Pool does not have enough liquidity
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -684,12 +740,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error No live fixed prices 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -700,7 +765,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -715,22 +782,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -738,7 +799,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -764,35 +833,36 @@ Array [
       >
         Error Code: 7
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        No live fixed prices for loan token
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      No live fixed prices for loan token
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -856,12 +926,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error Swap price is higher than the range allowed by the slippage tolerance. Increase tolerance percentage to proceed. 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -872,7 +951,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -887,22 +968,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -910,7 +985,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -936,35 +1019,36 @@ Array [
       >
         Error Code: 0
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        Swap price is higher than the range allowed by the slippage tolerance. Increase tolerance percentage to proceed.
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      Swap price is higher than the range allowed by the slippage tolerance. Increase tolerance percentage to proceed.
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -1028,28 +1112,31 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error UnknownError 1`] = `
-Array [
-  <Text />,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
     }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  }
+>
+  <Text />
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -1057,7 +1144,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -1083,35 +1178,36 @@ Array [
       >
         Error Code: 0
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        UnknownError
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      UnknownError
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -1175,12 +1271,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error Vault does not have enough collateralization ratio defined by loan scheme 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -1191,7 +1296,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -1206,22 +1313,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -1229,7 +1330,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -1255,35 +1364,36 @@ Array [
       >
         Error Code: 8
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        Vault does not have enough col. ratio
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      Vault does not have enough col. ratio
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -1347,12 +1457,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error amount is less than 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -1363,7 +1482,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -1378,22 +1499,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -1401,7 +1516,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -1427,35 +1550,36 @@ Array [
       >
         Error Code: 2
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        Not enough balance
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      Not enough balance
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -1519,12 +1643,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error no prevouts available to create a transaction 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -1535,7 +1668,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -1550,22 +1685,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -1573,7 +1702,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -1599,35 +1736,36 @@ Array [
       >
         Error Code: 1
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        Insufficient UTXO DFI
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      Insufficient UTXO DFI
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -1691,12 +1829,21 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;
 
 exports[`info text should match snapshot for error not enough balance after combing all prevouts 1`] = `
-Array [
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
+>
   <Text
     allowFontScaling={false}
     selectable={false}
@@ -1707,7 +1854,9 @@ Array [
           "fontSize": 20,
         },
         Array [
-          undefined,
+          Object {
+            "width": "8.333333%",
+          },
           Object {
             "color": "rgba(255, 0, 0, 1)",
           },
@@ -1722,22 +1871,16 @@ Array [
     }
   >
     
-  </Text>,
-  <RCTScrollView
-    contentContainerStyle={
-      Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "justifyContent": "center",
-      }
-    }
-    horizontal={true}
-    showsHorizontalScrollIndicator={false}
+  </Text>
+  <View
     style={
       Array [
         Object {
-          "marginLeft": 12,
-          "marginRight": 12,
+          "display": "flex",
+          "flexDirection": "column",
+          "justifyContent": "center",
+          "marginLeft": 4,
+          "width": "75%",
         },
         Object {
           "backgroundColor": "rgba(255, 255, 255, 1)",
@@ -1745,7 +1888,15 @@ Array [
       ]
     }
   >
-    <View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        }
+      }
+    >
       <Text
         style={
           Array [
@@ -1771,35 +1922,36 @@ Array [
       >
         Error Code: 1
       </Text>
-      <Text
-        ellipsizeMode="tail"
-        numberOfLines={1}
-        style={
+    </View>
+    <Text
+      ellipsizeMode="tail"
+      numberOfLines={false}
+      onTextLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "fontFamily": "RegularFont",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "lineHeight": 24,
+          },
           Array [
             Object {
-              "fontFamily": "RegularFont",
-              "fontSize": 16,
-              "fontWeight": "400",
-              "lineHeight": 24,
+              "fontFamily": "BoldFont",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "lineHeight": 20,
             },
-            Array [
-              Object {
-                "fontFamily": "BoldFont",
-                "fontSize": 14,
-                "fontWeight": "700",
-                "lineHeight": 20,
-              },
-              Object {
-                "color": "rgba(0, 0, 0, 1)",
-              },
-            ],
-          ]
-        }
-      >
-        Insufficient UTXO DFI
-      </Text>
-    </View>
-  </RCTScrollView>,
+            Object {
+              "color": "rgba(0, 0, 0, 1)",
+            },
+          ],
+        ]
+      }
+    >
+      Insufficient UTXO DFI
+    </Text>
+  </View>
   <View
     accessible={true}
     collapsable={false}
@@ -1863,6 +2015,6 @@ Array [
     >
       OK
     </Text>
-  </View>,
-]
+  </View>
+</View>
 `;

--- a/mobile-app/app/components/OceanInterface/__snapshots__/TransactionError.test.tsx.snap
+++ b/mobile-app/app/components/OceanInterface/__snapshots__/TransactionError.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`info text should match snapshot for error At least 50% of the vault mus
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -278,7 +278,7 @@ exports[`info text should match snapshot for error Cannot payback loan while any
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -464,7 +464,7 @@ exports[`info text should match snapshot for error Error: Not found, code: 404, 
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -650,7 +650,7 @@ exports[`info text should match snapshot for error Lack of liquidity 1`] = `
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -836,7 +836,7 @@ exports[`info text should match snapshot for error No live fixed prices 1`] = `
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -1022,7 +1022,7 @@ exports[`info text should match snapshot for error Swap price is higher than the
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -1181,7 +1181,7 @@ exports[`info text should match snapshot for error UnknownError 1`] = `
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -1367,7 +1367,7 @@ exports[`info text should match snapshot for error Vault does not have enough co
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -1553,7 +1553,7 @@ exports[`info text should match snapshot for error amount is less than 1`] = `
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -1739,7 +1739,7 @@ exports[`info text should match snapshot for error no prevouts available to crea
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [
@@ -1925,7 +1925,7 @@ exports[`info text should match snapshot for error not enough balance after comb
     </View>
     <Text
       ellipsizeMode="tail"
-      numberOfLines={false}
+      numberOfLines={0}
       onTextLayout={[Function]}
       style={
         Array [


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
Expand error text in ocean interface if error message is too big. `onTextLayout` dose not work on desktop so for desktop this will show half error message with ellipses at the tail.

https://user-images.githubusercontent.com/53080940/170472822-265dc2d8-2c5b-4a27-93c8-5cd9db00fd72.mp4


#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1500

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
