### PR TITLE
fix(e2e): click on visible header network icon

### DIFF
--- a/mobile-app/cypress/e2e/functional/wallet/settings/networkDetails.spec.ts
+++ b/mobile-app/cypress/e2e/functional/wallet/settings/networkDetails.spec.ts
@@ -131,8 +131,6 @@ context('Wallet - Network detail screen - with wallet context', () => {
         cy.getByTestID('header_network_icon').filter(':visible').click()
         cy.getByTestID('network_details_network').should('exist').contains(network)
         cy.getByTestID(`button_network_${network}_check`).should('have.css', 'color', statusBgColor)
-        cy.go('back')
-        cy.getByTestID('header_network_icon').click()
         cy.getByTestID('button_network_Playground').click()
         cy.exitWallet()
         cy.createEmptyWallet(true)
@@ -140,7 +138,7 @@ context('Wallet - Network detail screen - with wallet context', () => {
         cy.getByTestID('header_network_icon').should('exist').wait(3000)
         cy.getByTestID('header_active_network').first().invoke('text').then((updatedNetwork: string) => {
           cy.getByTestID('header_network_icon').find('path').should('have.css', 'fill').then((updatedStatusBgColor) => {
-            cy.getByTestID('header_network_icon').click().wait(3000)
+            cy.getByTestID('header_network_icon').filter(':visible').click()
             expect(network).not.eq(updatedNetwork)
             cy.getByTestID('network_details_network').should('exist').contains(updatedNetwork)
             cy.getByTestID(`button_network_${updatedNetwork}_check`).should('have.css', 'color', updatedStatusBgColor)
@@ -153,7 +151,7 @@ context('Wallet - Network detail screen - with wallet context', () => {
   it('should be able to click block height and redirect it to defiscan', function () {
     cy.getByTestID('bottom_tab_portfolio').click()
     cy.getByTestID('header_settings').click().wait(3000)
-    cy.getByTestID('header_network_icon').should('exist').click()
+    cy.getByTestID('header_network_icon').filter(':visible').click()
     cy.getByTestID('block_detail_explorer_url').invoke('text').then((block) => {
       cy.getByTestID('block_detail_explorer_url').filter(':visible').click()
     })

--- a/mobile-app/cypress/e2e/functional/wallet/settings/networkDetails.spec.ts
+++ b/mobile-app/cypress/e2e/functional/wallet/settings/networkDetails.spec.ts
@@ -168,7 +168,7 @@ context('Wallet - Network detail screen - with wallet context go back check', ()
   it('should get back to the portfolio page when network detail called from portfolio page', function () {
     cy.getByTestID('bottom_tab_portfolio').click().wait(3000)
     cy.url().should('include', 'app/portfolio')
-    cy.getByTestID('portfolio_header_container').filter(':visible').click().wait(3000)
+    cy.getByTestID('header_active_network').first().click()
     cy.go('back')
     cy.url().should('include', 'app/portfolio')
   })

--- a/mobile-app/cypress/e2e/functional/wallet/settings/settings.spec.ts
+++ b/mobile-app/cypress/e2e/functional/wallet/settings/settings.spec.ts
@@ -4,7 +4,7 @@ context('Wallet - Settings', () => {
     cy.getByTestID('header_settings').click()
   })
 
-  it.only('should be able to display top up screen when click on playground on playground network', function () {
+  it('should be able to display top up screen when click on playground on playground network', function () {
     cy.getByTestID('header_network_icon').filter(':visible').click()
     cy.getByTestID('button_network_Playground').click()
     cy.on('window:confirm', () => {})

--- a/mobile-app/cypress/e2e/functional/wallet/settings/settings.spec.ts
+++ b/mobile-app/cypress/e2e/functional/wallet/settings/settings.spec.ts
@@ -4,13 +4,13 @@ context('Wallet - Settings', () => {
     cy.getByTestID('header_settings').click()
   })
 
-  it('should be able to display top up screen when click on playground on playground network', function () {
-    cy.getByTestID('header_network_icon').click()
+  it.only('should be able to display top up screen when click on playground on playground network', function () {
+    cy.getByTestID('header_network_icon').filter(':visible').click()
     cy.getByTestID('button_network_Playground').click()
     cy.on('window:confirm', () => {})
     cy.createEmptyWallet(true)
     cy.getByTestID('header_settings').click()
-    cy.getByTestID('header_network_icon').click()
+    cy.getByTestID('header_network_icon').filter(':visible').click()
     cy.getByTestID('button_network_Playground').click()
     cy.url().should('include', 'playground')
   })


### PR DESCRIPTION
Because of duplicate component in portfolio and setting headerRight

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
- To fix broken e2e that was introduced in PR #3195 , when `HeaderNetworkStatus` is added to portfolio's `headerRight` duplicated component is found in settings screen too, so need to pinpoint the exact one to use in e2e

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [x] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
