### PR TITLE
Remove screen name translations in navigators

### DIFF
--- a/mobile-app/app/screens/AppNavigator/BottomTabNavigator.tsx
+++ b/mobile-app/app/screens/AppNavigator/BottomTabNavigator.tsx
@@ -28,7 +28,7 @@ const getTabBarLabel = ({
   <Text style={{ color, ...tailwind('font-normal-v2 text-xs') }}>{focused ? title : ''}</Text>
 )
 
-export function BottomTabNavigator (): JSX.Element {
+export function BottomTabNavigator(): JSX.Element {
   const { isLight } = useThemeContext()
   return (
     <>
@@ -47,7 +47,7 @@ export function BottomTabNavigator (): JSX.Element {
       >
         <BottomTab.Screen
           component={PortfolioNavigator}
-          name={translate('BottomTabNavigator', 'Portfolio')}
+          name='Portfolio'
           options={{
             tabBarLabel: ({
               focused,
@@ -71,31 +71,31 @@ export function BottomTabNavigator (): JSX.Element {
 
         <BottomTab.Screen
           component={DexNavigator}
-          name={translate('BottomTabNavigator', 'DEX')}
-          options={{
-            tabBarLabel: ({
-              focused,
-              color
-            }) => getTabBarLabel({
-              focused,
-              color,
-              title: translate('BottomTabNavigator', 'DEX')
-            }),
-            tabBarTestID: 'bottom_tab_dex',
-            tabBarIcon: ({
-              color
-            }) => (
-              <DEXIcon
-                color={color}
-                size={24}
-              />
-            )
-          }}
+          name=DEX'
+        options={{
+          tabBarLabel: ({
+            focused,
+            color
+          }) => getTabBarLabel({
+            focused,
+            color,
+            title: translate('BottomTabNavigator', 'DEX')
+          }),
+          tabBarTestID: 'bottom_tab_dex',
+          tabBarIcon: ({
+            color
+          }) => (
+            <DEXIcon
+              color={color}
+              size={24}
+            />
+          )
+        }}
         />
 
         <BottomTab.Screen
           component={LoansNavigator}
-          name={translate('BottomTabNavigator', 'Loans')}
+          name='Loans'
           options={{
             tabBarLabel: ({
               focused,
@@ -119,7 +119,7 @@ export function BottomTabNavigator (): JSX.Element {
 
         <BottomTab.Screen
           component={AuctionsNavigator}
-          name={translate('BottomTabNavigator', 'Auctions')}
+          name='Auctions'
           options={{
             tabBarLabel: ({
               focused,

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/PortfolioNavigator.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/PortfolioNavigator.tsx
@@ -132,7 +132,7 @@ export interface ConversionParam {
 
 const PortfolioStack = createStackNavigator<PortfolioParamList>()
 
-export function PortfolioNavigator (): JSX.Element {
+export function PortfolioNavigator(): JSX.Element {
   const navigation = useNavigation<NavigationProp<PortfolioParamList>>()
   const headerContainerTestId = 'portfolio_header_container'
   const { isLight } = useThemeContext()
@@ -150,7 +150,7 @@ export function PortfolioNavigator (): JSX.Element {
     >
       <PortfolioStack.Screen
         component={SettingsNavigator}
-        name={translate('PortfolioNavigator', 'Settings')}
+        name='Settings'
         options={{
           headerShown: false
         }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:
Names of Screens in Navigators should not be translated because they will be used as keys for deep linking.
#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3383

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [x] No console errors on web
- [x] Tested on Light mode and Dark mode*
- [x] Your UI implementation visually matched the rendered design*

<!-- 
* If applicable 
-->
