### PR TITLE
chore(ui-ux): auto scroll top when switch between instant/future swap tabs

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Platform, TextInput, View } from "react-native";
+import { Platform, ScrollView, TextInput, View } from "react-native";
 import { useSelector } from "react-redux";
 import { Controller, useForm } from "react-hook-form";
 import BigNumber from "bignumber.js";
@@ -187,6 +187,7 @@ export function CompositeSwapScreenV2({ route }: Props): JSX.Element {
     toTokenDisplaySymbol: selectedTokenB?.displaySymbol,
   });
   const amountInputRef = useRef<TextInput>();
+  const scrollViewRef = useRef<ScrollView>();
 
   const {
     bottomSheetRef,
@@ -220,6 +221,10 @@ export function CompositeSwapScreenV2({ route }: Props): JSX.Element {
 
   const onButtonGroupChange = (buttonGroupTabKey: ButtonGroupTabKey): void => {
     setActiveButtonGroup(buttonGroupTabKey);
+    scrollViewRef.current?.scrollTo({
+      y: 0,
+      animated: false,
+    });
   };
 
   // component UI state
@@ -758,7 +763,7 @@ export function CompositeSwapScreenV2({ route }: Props): JSX.Element {
           (isToLoanToken !== undefined && !isToLoanToken)
         }
       />
-      <ThemedScrollView>
+      <ThemedScrollView ref={scrollViewRef}>
         {activeButtonGroup === ButtonGroupTabKey.InstantSwap &&
           isDexStabilizationEnabled &&
           dexStabilizationType !== "none" &&


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:
Auto scroll to top while switching between instant/future swap tabs. Similar to "Available pairs" and "Your pool pairs" in Dex screen

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
