### PR TITLE
feature(core): replace reserve with token b value equivalent

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
@@ -598,6 +598,10 @@ export function CompositeSwapScreenV2({ route }: Props): JSX.Element {
 
   const navigateToTokenSelectionScreen = (listType: TokenListType): void => {
     navigation.navigate("SwapTokenSelectionScreen", {
+      fromToken: {
+        symbol: selectedTokenA?.symbol,
+        displaySymbol: selectedTokenA?.displaySymbol,
+      },
       listType: listType,
       list: listType === TokenListType.From ? fromTokens ?? [] : toTokens ?? [],
       onTokenPress: (item) => {

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
@@ -177,6 +177,7 @@ export function CompositeSwapScreenV2({ route }: Props): JSX.Element {
   const { fromTokens, toTokens } = useSwappableTokensV2(
     selectedTokenA?.id,
     selectedTokenA?.displaySymbol,
+    selectedTokenA?.symbol,
     activeButtonGroup === ButtonGroupTabKey.FutureSwap
   );
   const {

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
@@ -1089,7 +1089,7 @@ export function CompositeSwapScreenV2({ route }: Props): JSX.Element {
                   status={
                     route.params.tokenSelectOption?.to?.isDisabled
                       ? TokenDropdownButtonStatus.Locked
-                      : selectedTokenA === undefined
+                      : selectedTokenA === undefined || toTokens.length === 0
                       ? TokenDropdownButtonStatus.Disabled
                       : TokenDropdownButtonStatus.Enabled
                   }

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/DexNavigator.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/DexNavigator.tsx
@@ -58,6 +58,10 @@ export interface DexParamList {
     };
   };
   SwapTokenSelectionScreen: {
+    fromToken: {
+      symbol?: string;
+      displaySymbol?: string;
+    };
     listType: TokenListType;
     list: SelectionToken[];
     onTokenPress: (token: SelectionToken) => void;

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/hook/SwappableTokensV2.ts
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/hook/SwappableTokensV2.ts
@@ -2,7 +2,12 @@ import { useCallback, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import BigNumber from "bignumber.js";
 import { RootState } from "@store";
-import { DexItem, fetchSwappableTokens, tokensSelector } from "@store/wallet";
+import {
+  DexItem,
+  fetchDexPrice,
+  fetchSwappableTokens,
+  tokensSelector,
+} from "@store/wallet";
 import { useWhaleApiClient } from "@shared-contexts/WhaleContext";
 import { BottomSheetToken } from "@components/BottomSheetTokenList";
 import { CacheApi } from "@api/cache";
@@ -12,6 +17,7 @@ import { AllSwappableTokensResult } from "@defichain/whale-api-client/dist/api/p
 import { useAppDispatch } from "@hooks/useAppDispatch";
 import { loanTokensSelector } from "@store/loans";
 import { TokenState } from "../CompositeSwap/CompositeSwapScreenV2";
+import { useTokenPrice } from "../../Portfolio/hooks/TokenPrice";
 
 interface TokenPrice {
   toTokens: BottomSheetToken[];
@@ -21,6 +27,7 @@ interface TokenPrice {
 export function useSwappableTokensV2(
   fromTokenId: string | undefined,
   fromTokenDisplaySymbol: string | undefined,
+  fromTokenSymbol: string | undefined,
   isFutureSwap: boolean
 ): TokenPrice {
   const client = useWhaleApiClient();
@@ -40,10 +47,23 @@ export function useSwappableTokensV2(
   const [fromTokens, setFromTokens] = useState<BottomSheetToken[]>([]);
   const [allTokens, setAllTokens] = useState<TokenState[]>();
 
+  const { getTokenPrice } = useTokenPrice(fromTokenSymbol ?? "USDT");
+
   const cacheKey = `WALLET.${network}.${blockCount ?? 0}.SWAP_FROM_${
     fromTokenId ?? 0
   }`;
   const cachedData = CacheApi.get(cacheKey);
+
+  useFocusEffect(
+    useCallback(() => {
+      dispatch(
+        fetchDexPrice({
+          client,
+          denomination: fromTokenSymbol ?? "USDT",
+        })
+      );
+    }, [blockCount, fromTokenSymbol])
+  );
 
   /* Opted out of using useMemo to ensure it'll only run when screen is focused */
   useFocusEffect(
@@ -141,7 +161,7 @@ export function useSwappableTokensV2(
 
         return {
           tokenId: tokenId,
-          available: new BigNumber(NaN),
+          available: getTokenPrice(token.symbol, new BigNumber(1), false),
           token: {
             displaySymbol: token.displaySymbol,
             name: token.name ?? "",

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/hook/SwappableTokensV2.ts
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/hook/SwappableTokensV2.ts
@@ -94,7 +94,6 @@ export function useSwappableTokensV2(
               name: token.name ?? "",
               symbol: token.symbol,
             },
-            reserve: token.reserve,
           };
         })
         .sort((a, b) => b.available.minus(a.available).toNumber());
@@ -139,17 +138,15 @@ export function useSwappableTokensV2(
       .filter((t) => t.displaySymbol !== "dBURN" && !t.symbol.includes("/v1"))
       .map((token) => {
         const tokenId = token.id === "0" ? "0_unified" : token.id;
-        const tokenData = allTokens.find((t) => t.id === token.id);
 
         return {
           tokenId: tokenId,
-          available: new BigNumber(tokenData?.reserve ?? NaN),
+          available: new BigNumber(NaN),
           token: {
             displaySymbol: token.displaySymbol,
             name: token.name ?? "",
             symbol: token.symbol,
           },
-          reserve: tokenData?.reserve ?? "", // TODO(PIERRE): Ask whale to add reserve on response
         };
       })
       .sort((a, b) => new BigNumber(a.tokenId).minus(b.tokenId).toNumber());


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
- [x] Initial work to display the tokenB equivalent and usdValue in toToken
- [ ] Improve performance. The denomination API is called every time the Token Selection screen is opened

The value is the reserve of the token
We are retrieving it in the poolpairs API by first occurence
DFI-dETH --> 17M DFI reserve
DFI-dBTC --> 67M DFI reserve
but the reserve differs on each poolpair and we may be displaying the incorrect value
![image](https://user-images.githubusercontent.com/13292662/189829457-09201d4a-af06-4d9b-8cc4-bba8d62a868a.png)

To fix this issue, we will display the equivalent value of 1 tokenA in tokenB
If your From token is DFI
```
Value displayed = 0.00004454 dBTC // 1 DFI = 0.00004454 dBTC
```


#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
