### PR TITLE
feature(ui-ux): settlement block time display on swap and confirm v2

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/CompositeSwapScreenV2.tsx
@@ -170,7 +170,7 @@ export function CompositeSwapScreenV2({ route }: Props): JSX.Element {
   const executionBlock = useSelector(
     (state: RootState) => state.futureSwaps.executionBlock
   );
-  const { transactionDate, isEnded } = useFutureSwapDate(
+  const { timeRemaining, transactionDate, isEnded } = useFutureSwapDate(
     executionBlock,
     blockCount
   );
@@ -1141,6 +1141,7 @@ export function CompositeSwapScreenV2({ route }: Props): JSX.Element {
                   totalFees={totalFees}
                   dexStabilizationFee={dexStabilizationFee}
                   dexStabilizationType={dexStabilizationType}
+                  timeRemaining={timeRemaining}
                 />
               </ThemedViewV2>
             </>

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/components/SwapSummary.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/components/SwapSummary.tsx
@@ -21,6 +21,7 @@ interface SwapSummaryProps {
   totalFees: string;
   dexStabilizationFee: string;
   dexStabilizationType: DexStabilizationType;
+  timeRemaining: string;
 }
 
 export function SwapSummary({
@@ -32,6 +33,7 @@ export function SwapSummary({
   totalFees,
   dexStabilizationFee,
   dexStabilizationType,
+  timeRemaining,
 }: SwapSummaryProps): JSX.Element {
   const { getTokenPrice } = useTokenPrice();
 
@@ -97,6 +99,7 @@ export function SwapSummary({
           <SettlementBlockInfo
             executionBlock={executionBlock}
             transactionDate={transactionDate}
+            timeRemaining={timeRemaining}
           />
           <NumberRowV2
             containerStyle={{
@@ -196,10 +199,11 @@ function SettlementMessage(): JSX.Element {
 
 function SettlementBlockInfo({
   executionBlock,
-  transactionDate,
+  timeRemaining,
 }: {
   executionBlock?: number;
   transactionDate?: string;
+  timeRemaining: string;
 }): JSX.Element {
   const { getBlocksCountdownUrl } = useDeFiScanContext();
 
@@ -231,42 +235,37 @@ function SettlementBlockInfo({
           onPress={onBlockUrlPressed}
           testID="block_detail_explorer_url"
         >
-          <NumberFormat
-            displayType="text"
-            renderText={(val: string) => (
-              <ThemedTextV2
-                light={tailwind("text-mono-light-v2-900")}
-                dark={tailwind("text-mono-dark-v2-900")}
-                style={tailwind("text-sm font-normal-v2 flex-wrap text-right")}
-                testID="execution_block"
-              >
-                {val}
-              </ThemedTextV2>
-            )}
-            thousandSeparator
-            value={executionBlock}
-          />
           <View style={tailwind("flex-row items-center justify-end")}>
-            <ThemedTextV2
-              light={tailwind("text-mono-light-v2-700")}
-              dark={tailwind("text-mono-dark-v2-700")}
-              style={tailwind("text-right text-sm font-normal-v2")}
-              testID="execution_block_date"
-            >
-              {transactionDate}
-            </ThemedTextV2>
-
-            <View style={tailwind("ml-1 flex-grow-0 justify-center")}>
-              <ThemedIcon
-                iconType="MaterialIcons"
-                light={tailwind("text-mono-light-v2-700")}
-                dark={tailwind("text-mono-dark-v2-700")}
-                name="open-in-new"
-                size={16}
-              />
-            </View>
+            <NumberFormat
+              displayType="text"
+              renderText={(val: string) => (
+                <ThemedTextV2
+                  light={tailwind("text-mono-light-v2-900")}
+                  dark={tailwind("text-mono-dark-v2-900")}
+                  style={tailwind(
+                    "text-sm font-normal-v2 flex-wrap text-right pr-1"
+                  )}
+                  testID="execution_block"
+                >
+                  {val}
+                </ThemedTextV2>
+              )}
+              thousandSeparator
+              value={executionBlock}
+            />
+            <ThemedIcon iconType="MaterialIcons" name="open-in-new" size={16} />
           </View>
         </TouchableOpacity>
+        <View style={tailwind("flex-row items-center justify-end")}>
+          <ThemedTextV2
+            light={tailwind("text-mono-light-v2-700")}
+            dark={tailwind("text-mono-dark-v2-700")}
+          >
+            {translate("screens/CompositeSwapScreen", "{{time}} left", {
+              time: timeRemaining.trim(),
+            })}
+          </ThemedTextV2>
+        </View>
       </View>
     </ThemedViewV2>
   );

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/hook/FutureSwap.ts
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/hook/FutureSwap.ts
@@ -99,7 +99,7 @@ export function useFutureSwapDate(
       blocksRemaining > 0 ? secondsToDhmsDisplay(blocksSeconds) : "",
     transactionDate: dayjs()
       .add(blocksSeconds, "second")
-      .format("MMM D, YYYY, h:mm a"),
+      .format("MMM D, YYYY, hh:mm a"),
     isEnded: blocksRemaining === 0,
   };
 }

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/hook/FutureSwap.ts
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/hook/FutureSwap.ts
@@ -99,7 +99,7 @@ export function useFutureSwapDate(
       blocksRemaining > 0 ? secondsToDhmsDisplay(blocksSeconds) : "",
     transactionDate: dayjs()
       .add(blocksSeconds, "second")
-      .format("MMM D, YYYY, hh:mm a"),
+      .format("MMM D, YYYY, h:mm a"),
     isEnded: blocksRemaining === 0,
   };
 }

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/hook/FutureSwap.ts
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/hook/FutureSwap.ts
@@ -97,7 +97,9 @@ export function useFutureSwapDate(
   return {
     timeRemaining:
       blocksRemaining > 0 ? secondsToDhmsDisplay(blocksSeconds) : "",
-    transactionDate: dayjs().add(blocksSeconds, "second").format("MMM D, YYYY"),
+    transactionDate: dayjs()
+      .add(blocksSeconds, "second")
+      .format("MMM D, YYYY, HH:mm a"),
     isEnded: blocksRemaining === 0,
   };
 }

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/hook/FutureSwap.ts
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/hook/FutureSwap.ts
@@ -99,7 +99,7 @@ export function useFutureSwapDate(
       blocksRemaining > 0 ? secondsToDhmsDisplay(blocksSeconds) : "",
     transactionDate: dayjs()
       .add(blocksSeconds, "second")
-      .format("MMM D, YYYY, HH:mm a"),
+      .format("MMM D, YYYY, h:mm a"),
     isEnded: blocksRemaining === 0,
   };
 }

--- a/shared/translations/languages/de.json
+++ b/shared/translations/languages/de.json
@@ -1004,6 +1004,7 @@
     "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block": "Mit dem Future Swap verkaufst du {{tokenSymbol}} um 5% unter dem Preisorakelwert zum Abrechnungs-Block.",
     "Oracle price {{percentageChange}}": "Preisorakelwert {{percentageChange}}",
     "Est. time remaining": "Verbleibende geschätzte Zeit",
+    "{{time}} left": "Noch {{time}}",
     "Settlement block": "Abrechnungs-Block",
     "To be confirmed": "Noch zu bestätigen",
     "Enter an amount": "Gib einen Betrag ein",

--- a/shared/translations/languages/es.json
+++ b/shared/translations/languages/es.json
@@ -1028,6 +1028,7 @@
     "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block": "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block",
     "Oracle price {{percentageChange}}": "Oracle price {{percentageChange}}",
     "Est. time remaining": "Est. time remaining",
+    "{{time}} left": "{{time}} restante",
     "Settlement block": "Settlement block",
     "To be confirmed": "To be confirmed",
     "Enter an amount": "Enter an amount",
@@ -1845,7 +1846,7 @@
     "Future Swap": "Future Swap",
     "Settlement block {{block}} has been executed": "El bloque de asentamiento {{block}} ha sido ejecutado",
     "Target block": "Target block",
-    "{{time}} left": "{{time}} left",
+    "{{time}} left": "{{time}} restante",
     "to": "to",
     "Settlement value": "Settlement value",
     "Amount will be refunded automatically if transaction(s) failed": "Amount will be refunded automatically if transaction(s) failed"

--- a/shared/translations/languages/fr.json
+++ b/shared/translations/languages/fr.json
@@ -1016,7 +1016,7 @@
     "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block": "En utilisant le Future Swap, vous vendez {{tokenSymbol}} à un prix inférieur de 5% au prix oracle au bloc de règlement",
     "Oracle price {{percentageChange}}": "Prix Oracle {{percentageChange}}",
     "Est. time remaining": "Temps estimé restant",
-    "~{{time}} left": "{{time}} restant",
+    "{{time}} left": "{{time}} restant",
     "Settlement block": "Bloc de règlement",
     "To be confirmed": "À confirmer",
     "Enter an amount": "Donnez un montant",

--- a/shared/translations/languages/fr.json
+++ b/shared/translations/languages/fr.json
@@ -1016,6 +1016,7 @@
     "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block": "En utilisant le Future Swap, vous vendez {{tokenSymbol}} à un prix inférieur de 5% au prix oracle au bloc de règlement",
     "Oracle price {{percentageChange}}": "Prix Oracle {{percentageChange}}",
     "Est. time remaining": "Temps estimé restant",
+    "~{{time}} left": "{{time}} restant",
     "Settlement block": "Bloc de règlement",
     "To be confirmed": "À confirmer",
     "Enter an amount": "Donnez un montant",

--- a/shared/translations/languages/it.json
+++ b/shared/translations/languages/it.json
@@ -1026,6 +1026,7 @@
     "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block": "Utilizzando il future swap, stai vendendo {{tokenSymbol}} al 5% in meno rispetto al prezzo oracolo al Blocco di regolamento",
     "Oracle price {{percentageChange}}": "Prezzo Oracolo {{percentageChange}}",
     "Est. time remaining": "Tempo rimanente stimato",
+    "{{time}} left": "{{time}} rimasto",
     "Settlement block": "Blocco di regolamento",
     "To be confirmed": "Da confermare",
     "Enter an amount": "Inserisci un importo",

--- a/shared/translations/languages/zh-Hans.json
+++ b/shared/translations/languages/zh-Hans.json
@@ -1008,6 +1008,7 @@
     "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block": "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block",
     "Oracle price {{percentageChange}}": "Oracle price {{percentageChange}}",
     "Est. time remaining": "Est. time remaining",
+    "{{time}} left": "{{time}} 结束拍卖",
     "Settlement block": "Settlement block",
     "To be confirmed": "To be confirmed",
     "Enter an amount": "请输入数量",
@@ -1822,7 +1823,7 @@
     "Future Swap": "Future Swap",
     "Settlement block {{block}} has been executed": "结算区块 {{block}} 已执行",
     "Target block": "Target block",
-    "{{time}} left": "{{time}} left",
+    "{{time}} left": "{{time}} 结束拍卖",
     "to": "to",
     "Settlement value": "Settlement value",
     "Amount will be refunded automatically if transaction(s) failed": "Amount will be refunded automatically if transaction(s) failed"

--- a/shared/translations/languages/zh-Hant.json
+++ b/shared/translations/languages/zh-Hant.json
@@ -1008,6 +1008,7 @@
     "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block": "By using future swap, you are selling {{tokenSymbol}} at 5% lower than the oracle price at Settlement block",
     "Oracle price {{percentageChange}}": "Oracle price {{percentageChange}}",
     "Est. time remaining": "Est. time remaining",
+    "{{time}} left": "{{time}} 結束拍賣",
     "Settlement block": "Settlement block",
     "To be confirmed": "To be confirmed",
     "Enter an amount": "請輸入數量",
@@ -1823,7 +1824,7 @@
     "Future Swap": "Future Swap",
     "Settlement block {{block}} has been executed": "結算區塊 {{block}} 已執行",
     "Target block": "Target block",
-    "{{time}} left": "{{time}} left",
+    "{{time}} left": "{{time}} 結束拍賣",
     "to": "to",
     "Settlement value": "Settlement value",
     "Amount will be refunded automatically if transaction(s) failed": "Amount will be refunded automatically if transaction(s) failed"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
- Display block countdown time and link block number to explorer in swap page 
- Reformat display time in confirm page 

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
![image](https://user-images.githubusercontent.com/44501120/190052943-695cf5ce-4767-4c1e-aaec-5fc9069ca6b0.png)

![image](https://user-images.githubusercontent.com/44501120/190052922-3299e7aa-0624-4b4f-bc10-a5bfffd787ca.png)
