### PR TITLE
fix(ui-ux): update x behaviour on slippage tolerance

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/components/SlippageToleranceV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/components/SlippageToleranceV2.tsx
@@ -70,14 +70,8 @@ export function SlippageToleranceV2({
   };
 
   const validateSlippage = (value: string): void => {
+    /* Allow empty custom slippage -> reverts back to previous slippage */
     if (value === undefined || value === "") {
-      setSlippageError({
-        type: "error",
-        text: translate(
-          "screens/SlippageTolerance",
-          "Required field is missing"
-        ),
-      });
       return;
     } else if (
       !(new BigNumber(value).gte(0) && new BigNumber(value).lte(100))
@@ -136,15 +130,13 @@ export function SlippageToleranceV2({
                 }}
                 keyboardType="numeric"
                 autoCapitalize="none"
-                placeholder="0.00%"
                 style={tailwind("flex-grow w-2/5 font-normal-v2 text-xs")}
                 inputContainerStyle={tailwind("h-9")}
                 testID="slippage_input"
                 value={selectedSlippage !== undefined ? selectedSlippage : ""}
                 displayClearButton={selectedSlippage !== ""}
                 onClearButtonPress={() => {
-                  setIsEditing(false);
-                  setSelectedSlippage(new BigNumber(slippage).toFixed(8));
+                  setSelectedSlippage("");
                 }}
                 inputType="numeric"
                 inlineText={slippageError}
@@ -165,14 +157,21 @@ export function SlippageToleranceV2({
                 )}
                 onPress={() => {
                   setIsEditing(false);
-                  setIsCustomAmount(true);
-                  setSelectedSlippage(
-                    new BigNumber(selectedSlippage).toFixed(8)
-                  );
-                  submitSlippage(
-                    new BigNumber(selectedSlippage),
-                    isCustomValue
-                  );
+                  if (
+                    selectedSlippage === undefined ||
+                    selectedSlippage === ""
+                  ) {
+                    setSelectedSlippage(new BigNumber(slippage).toFixed(8));
+                  } else {
+                    setIsCustomAmount(true);
+                    setSelectedSlippage(
+                      new BigNumber(selectedSlippage).toFixed(8)
+                    );
+                    submitSlippage(
+                      new BigNumber(selectedSlippage),
+                      isCustomValue
+                    );
+                  }
                 }}
                 disabled={!isSlippageValid()}
                 testID="set_slippage_button"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
- Remove the 0.00 placeholder because 0 is a valid slippage tolerance and might confuse the user
- User is allowed to click the Set button with empty input -> This will revert to previous custom slippage

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
