### PR TITLE
fix(ui-ux): fix issue when switching wallet by unmounting screens on blur

### DIFF
--- a/mobile-app/app/screens/AppNavigator/BottomTabNavigator.tsx
+++ b/mobile-app/app/screens/AppNavigator/BottomTabNavigator.tsx
@@ -92,6 +92,7 @@ export function BottomTabNavigator(): JSX.Element {
               }),
             tabBarTestID: "bottom_tab_dex",
             tabBarIcon: ({ color }) => <DEXIcon color={color} size={24} />,
+            unmountOnBlur: true,
           }}
         />
 
@@ -107,6 +108,7 @@ export function BottomTabNavigator(): JSX.Element {
               }),
             tabBarTestID: "bottom_tab_loans",
             tabBarIcon: ({ color }) => <LoansIcon color={color} size={24} />,
+            unmountOnBlur: true,
           }}
         />
 
@@ -122,6 +124,7 @@ export function BottomTabNavigator(): JSX.Element {
               }),
             tabBarTestID: "bottom_tab_auctions",
             tabBarIcon: ({ color }) => <AuctionsIcon color={color} size={24} />,
+            unmountOnBlur: true,
           }}
         />
       </BottomTab.Navigator>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
- Fix issue when switching wallet right after starting any transaction (from other tabs). 
- Change: always unmount screen when switching to a different tab.
- Tabs affected: Dex, Loans, and Auctions

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
This change is just a workaround, ideally we should only unmount previous screen After wallet address has been successfully switched.

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
