### PR TITLE
fix(ui-ux): added onPress UI state for quick input

### DIFF
--- a/mobile-app/app/components/TransactionCard.tsx
+++ b/mobile-app/app/components/TransactionCard.tsx
@@ -123,7 +123,7 @@ function SetAmountButton({
 }: SetAmountButtonProps): JSX.Element {
   const decimalPlace = 8;
   let value = amount.toFixed(decimalPlace);
-  const [userPressedState, setUserPressedState] = useState(false);
+  const [isPressed, setIsPressed] = useState(false);
 
   switch (type) {
     case AmountButtonTypes.TwentyFive:
@@ -146,8 +146,8 @@ function SetAmountButton({
       onPress={() => {
         onPress(value, type);
       }}
-      onPressIn={() => setUserPressedState(true)}
-      onPressOut={() => setUserPressedState(false)}
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
       testID={`${type}_amount_button`}
       disabled={disabled}
     >
@@ -158,10 +158,10 @@ function SetAmountButton({
       >
         <ThemedViewV2
           light={tailwind({
-            "bg-mono-light-v2-100 rounded-lg-v2": userPressedState,
+            "bg-mono-light-v2-100 rounded-lg-v2": isPressed,
           })}
           dark={tailwind({
-            "bg-mono-dark-v2-100 rounded-lg-v2": userPressedState,
+            "bg-mono-dark-v2-100 rounded-lg-v2": isPressed,
           })}
           style={tailwind("mx-1")}
         >

--- a/mobile-app/app/components/TransactionCard.tsx
+++ b/mobile-app/app/components/TransactionCard.tsx
@@ -8,6 +8,7 @@ import BigNumber from "bignumber.js";
 import { tailwind } from "@tailwind";
 import { translate } from "@translations";
 import { StyleProp, ViewStyle } from "react-native";
+import { useState } from "react";
 
 interface TransactionCardProps {
   maxValue: BigNumber;
@@ -83,7 +84,7 @@ export function TransactionCard({
           }
           dark={amountButtonsStyle?.dark ?? tailwind("border-mono-dark-v2-300")}
           style={[
-            tailwind("flex flex-row justify-around items-center py-2.5"),
+            tailwind("flex flex-row justify-center items-center py-2"),
             amountButtonsStyle?.style,
           ]}
         >
@@ -122,6 +123,7 @@ function SetAmountButton({
 }: SetAmountButtonProps): JSX.Element {
   const decimalPlace = 8;
   let value = amount.toFixed(decimalPlace);
+  const [userPressedState, setUserPressedState] = useState(false);
 
   switch (type) {
     case AmountButtonTypes.TwentyFive:
@@ -144,6 +146,8 @@ function SetAmountButton({
       onPress={() => {
         onPress(value, type);
       }}
+      onPressIn={() => setUserPressedState(true)}
+      onPressOut={() => setUserPressedState(false)}
       testID={`${type}_amount_button`}
       disabled={disabled}
     >
@@ -152,17 +156,27 @@ function SetAmountButton({
         dark={tailwind("border-mono-dark-v2-300")}
         style={tailwind({ "border-r-0.5": hasBorder })}
       >
-        <ThemedTextV2
-          light={tailwind("text-mono-light-v2-700", {
-            "opacity-30": disabled,
+        <ThemedViewV2
+          light={tailwind({
+            "bg-mono-light-v2-100 rounded-lg-v2": userPressedState,
           })}
-          dark={tailwind("text-mono-dark-v2-700", {
-            "opacity-30": disabled,
+          dark={tailwind({
+            "bg-mono-dark-v2-100 rounded-lg-v2": userPressedState,
           })}
-          style={tailwind("font-semibold-v2 text-xs px-7")}
+          style={tailwind("mx-1")}
         >
-          {translate("component/max", type)}
-        </ThemedTextV2>
+          <ThemedTextV2
+            light={tailwind("text-mono-light-v2-700", {
+              "opacity-30": disabled,
+            })}
+            dark={tailwind("text-mono-dark-v2-700", {
+              "opacity-30": disabled,
+            })}
+            style={tailwind("font-semibold-v2 text-xs px-6 py-1")}
+          >
+            {translate("component/max", type)}
+          </ThemedTextV2>
+        </ThemedViewV2>
       </ThemedViewV2>
     </ThemedTouchableOpacityV2>
   );

--- a/mobile-app/app/components/__snapshots__/TransactionCard.test.tsx.snap
+++ b/mobile-app/app/components/__snapshots__/TransactionCard.test.tsx.snap
@@ -78,9 +78,9 @@ exports[`Transaction Card should match snapshot 1`] = `
             "alignItems": "center",
             "display": "flex",
             "flexDirection": "row",
-            "justifyContent": "space-around",
-            "paddingBottom": 10,
-            "paddingTop": 10,
+            "justifyContent": "center",
+            "paddingBottom": 8,
+            "paddingTop": 8,
           },
           undefined,
         ],
@@ -134,33 +134,47 @@ exports[`Transaction Card should match snapshot 1`] = `
           ]
         }
       >
-        <Text
+        <View
           style={
             [
               {
-                "fontFamily": "RegularFont",
-                "fontSize": 16,
-                "fontWeight": "400",
-                "lineHeight": 24,
+                "marginLeft": 4,
+                "marginRight": 4,
               },
-              [
-                {
-                  "fontFamily": "SoraSemiBold",
-                  "fontSize": 12,
-                  "fontWeight": "600",
-                  "lineHeight": 16,
-                  "paddingLeft": 28,
-                  "paddingRight": 28,
-                },
-                {
-                  "color": "rgba(89, 89, 89, 1)",
-                },
-              ],
+              {},
             ]
           }
         >
-          25%
-        </Text>
+          <Text
+            style={
+              [
+                {
+                  "fontFamily": "RegularFont",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                },
+                [
+                  {
+                    "fontFamily": "SoraSemiBold",
+                    "fontSize": 12,
+                    "fontWeight": "600",
+                    "lineHeight": 16,
+                    "paddingBottom": 4,
+                    "paddingLeft": 24,
+                    "paddingRight": 24,
+                    "paddingTop": 4,
+                  },
+                  {
+                    "color": "rgba(89, 89, 89, 1)",
+                  },
+                ],
+              ]
+            }
+          >
+            25%
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -204,33 +218,47 @@ exports[`Transaction Card should match snapshot 1`] = `
           ]
         }
       >
-        <Text
+        <View
           style={
             [
               {
-                "fontFamily": "RegularFont",
-                "fontSize": 16,
-                "fontWeight": "400",
-                "lineHeight": 24,
+                "marginLeft": 4,
+                "marginRight": 4,
               },
-              [
-                {
-                  "fontFamily": "SoraSemiBold",
-                  "fontSize": 12,
-                  "fontWeight": "600",
-                  "lineHeight": 16,
-                  "paddingLeft": 28,
-                  "paddingRight": 28,
-                },
-                {
-                  "color": "rgba(89, 89, 89, 1)",
-                },
-              ],
+              {},
             ]
           }
         >
-          50%
-        </Text>
+          <Text
+            style={
+              [
+                {
+                  "fontFamily": "RegularFont",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                },
+                [
+                  {
+                    "fontFamily": "SoraSemiBold",
+                    "fontSize": 12,
+                    "fontWeight": "600",
+                    "lineHeight": 16,
+                    "paddingBottom": 4,
+                    "paddingLeft": 24,
+                    "paddingRight": 24,
+                    "paddingTop": 4,
+                  },
+                  {
+                    "color": "rgba(89, 89, 89, 1)",
+                  },
+                ],
+              ]
+            }
+          >
+            50%
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -274,33 +302,47 @@ exports[`Transaction Card should match snapshot 1`] = `
           ]
         }
       >
-        <Text
+        <View
           style={
             [
               {
-                "fontFamily": "RegularFont",
-                "fontSize": 16,
-                "fontWeight": "400",
-                "lineHeight": 24,
+                "marginLeft": 4,
+                "marginRight": 4,
               },
-              [
-                {
-                  "fontFamily": "SoraSemiBold",
-                  "fontSize": 12,
-                  "fontWeight": "600",
-                  "lineHeight": 16,
-                  "paddingLeft": 28,
-                  "paddingRight": 28,
-                },
-                {
-                  "color": "rgba(89, 89, 89, 1)",
-                },
-              ],
+              {},
             ]
           }
         >
-          75%
-        </Text>
+          <Text
+            style={
+              [
+                {
+                  "fontFamily": "RegularFont",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                },
+                [
+                  {
+                    "fontFamily": "SoraSemiBold",
+                    "fontSize": 12,
+                    "fontWeight": "600",
+                    "lineHeight": 16,
+                    "paddingBottom": 4,
+                    "paddingLeft": 24,
+                    "paddingRight": 24,
+                    "paddingTop": 4,
+                  },
+                  {
+                    "color": "rgba(89, 89, 89, 1)",
+                  },
+                ],
+              ]
+            }
+          >
+            75%
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -342,33 +384,47 @@ exports[`Transaction Card should match snapshot 1`] = `
           ]
         }
       >
-        <Text
+        <View
           style={
             [
               {
-                "fontFamily": "RegularFont",
-                "fontSize": 16,
-                "fontWeight": "400",
-                "lineHeight": 24,
+                "marginLeft": 4,
+                "marginRight": 4,
               },
-              [
-                {
-                  "fontFamily": "SoraSemiBold",
-                  "fontSize": 12,
-                  "fontWeight": "600",
-                  "lineHeight": 16,
-                  "paddingLeft": 28,
-                  "paddingRight": 28,
-                },
-                {
-                  "color": "rgba(89, 89, 89, 1)",
-                },
-              ],
+              {},
             ]
           }
         >
-          MAX
-        </Text>
+          <Text
+            style={
+              [
+                {
+                  "fontFamily": "RegularFont",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                },
+                [
+                  {
+                    "fontFamily": "SoraSemiBold",
+                    "fontSize": 12,
+                    "fontWeight": "600",
+                    "lineHeight": 16,
+                    "paddingBottom": 4,
+                    "paddingLeft": 24,
+                    "paddingRight": 24,
+                    "paddingTop": 4,
+                  },
+                  {
+                    "color": "rgba(89, 89, 89, 1)",
+                  },
+                ],
+              ]
+            }
+          >
+            MAX
+          </Text>
+        </View>
       </View>
     </View>
   </View>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
This PR fixes quick inputs pressed state 

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
1. added checks on user's onPressIn and onPressOut when onPressIn state becomes active and triggers background
2. updated margins and paddings for quickinput to reflect figma

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [x] No console errors on web
- [x] Tested on Light mode and Dark mode*
- [x] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
