### PR TITLE
fix(ui-ux): remove decimalScale from NumberFormat

### DIFF
--- a/mobile-app/app/components/ConfirmSummaryTitle.tsx
+++ b/mobile-app/app/components/ConfirmSummaryTitle.tsx
@@ -45,7 +45,6 @@ export function ConfirmSummaryTitle(
         <View style={tailwind("flex-row items-center mt-2")}>
           <IconA height={32} width={32} />
           <NumberFormat
-            decimalScale={8}
             displayType="text"
             renderText={(value) => (
               <ThemedTextV2
@@ -92,7 +91,6 @@ export function ConfirmSummaryTitle(
               </View>
             ) : (
               <NumberFormat
-                decimalScale={8}
                 displayType="text"
                 renderText={(value) => (
                   <ThemedTextV2

--- a/mobile-app/app/components/InfoRow.tsx
+++ b/mobile-app/app/components/InfoRow.tsx
@@ -3,6 +3,7 @@ import { translate } from "@translations";
 import { StyleProp, View, ViewStyle } from "react-native";
 import { NumericFormat as NumberFormat } from "react-number-format";
 import { BottomSheetInfo } from "@components/BottomSheetInfo";
+import BigNumber from "bignumber.js";
 import { ThemedProps, ThemedText, ThemedView } from "./themed";
 
 interface InfoRowProps {
@@ -87,7 +88,6 @@ export function InfoRow(props: InfoRowProps): JSX.Element {
         style={tailwind("flex-1 flex-row justify-end flex-wrap items-center")}
       >
         <NumberFormat
-          decimalScale={8}
           displayType="text"
           renderText={(val: string) => (
             <ThemedText
@@ -101,7 +101,7 @@ export function InfoRow(props: InfoRowProps): JSX.Element {
             </ThemedText>
           )}
           thousandSeparator
-          value={props.value}
+          value={BigNumber(props.value).toFixed(8)}
         />
         {typeof props.suffix === "string" ? (
           <ThemedText

--- a/mobile-app/app/components/InputHelperText.tsx
+++ b/mobile-app/app/components/InputHelperText.tsx
@@ -8,6 +8,7 @@ import {
 import { NumericFormat as NumberFormat } from "react-number-format";
 import { StyleProp, ViewProps } from "react-native";
 import { TextProps } from "@components";
+import BigNumber from "bignumber.js";
 import { SuffixType } from "./NumberRow";
 
 interface InputHelperTextProps extends React.PropsWithChildren<ViewProps> {
@@ -35,7 +36,6 @@ export function InputHelperText(props: InputHelperTextProps): JSX.Element {
       </ThemedText>
 
       <NumberFormat
-        decimalScale={8}
         displayType="text"
         renderText={(value) => (
           <ThemedText
@@ -49,7 +49,7 @@ export function InputHelperText(props: InputHelperTextProps): JSX.Element {
         )}
         suffix={props.suffixType !== "component" ? props.suffix : ""}
         thousandSeparator
-        value={props.content}
+        value={BigNumber(props.content).toFixed(8)}
       />
       {props.suffixType === "component" && props.children}
     </ThemedView>
@@ -71,7 +71,6 @@ export function InputHelperTextV2(props: InputHelperTextProps): JSX.Element {
       </ThemedTextV2>
 
       <NumberFormat
-        decimalScale={8}
         displayType="text"
         renderText={(value) => (
           <ThemedTextV2
@@ -85,7 +84,7 @@ export function InputHelperTextV2(props: InputHelperTextProps): JSX.Element {
         )}
         suffix={props.suffixType !== "component" ? props.suffix : ""}
         thousandSeparator
-        value={props.content}
+        value={BigNumber(props.content).toFixed(8)}
       />
       {props.suffixType === "component" && props.children}
     </ThemedViewV2>

--- a/mobile-app/app/components/NumberRow.tsx
+++ b/mobile-app/app/components/NumberRow.tsx
@@ -77,7 +77,6 @@ export function NumberRow(props: INumberRowProps): JSX.Element {
             style={tailwind("flex flex-row justify-end flex-wrap items-center")}
           >
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               prefix={props.rhs.prefix}
               renderText={(val: string) => (
@@ -112,7 +111,7 @@ export function NumberRow(props: INumberRowProps): JSX.Element {
                 </Text>
               )}
               thousandSeparator
-              value={props.rhs.value}
+              value={BigNumber(props.rhs.value).toFixed(8)}
             />
           </View>
         </View>

--- a/mobile-app/app/components/NumberRowV2.tsx
+++ b/mobile-app/app/components/NumberRowV2.tsx
@@ -100,7 +100,6 @@ export function NumberRowV2(props: INumberRowProps): JSX.Element {
               </View>
             )}
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               prefix={props.rhs.prefix}
               suffix={
@@ -121,7 +120,7 @@ export function NumberRowV2(props: INumberRowProps): JSX.Element {
                 </ThemedTextV2>
               )}
               thousandSeparator
-              value={props.rhs.value}
+              value={BigNumber(props.rhs.value).toFixed(8)}
             />
           </View>
         </View>
@@ -142,7 +141,6 @@ export function NumberRowV2(props: INumberRowProps): JSX.Element {
           {props.rhs.isOraclePrice === true && <IconTooltip />}
           {props.rhs.subValue !== undefined && (
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               prefix={props.rhs.subValue.prefix}
               suffix={props.rhs.subValue.suffix}
@@ -158,7 +156,7 @@ export function NumberRowV2(props: INumberRowProps): JSX.Element {
                 </ThemedTextV2>
               )}
               thousandSeparator
-              value={props.rhs.subValue.value}
+              value={BigNumber(props.rhs.subValue.value).toFixed(8)}
             />
           )}
           {props.rhs.isConverting !== undefined && (

--- a/mobile-app/app/components/SummaryTitle.tsx
+++ b/mobile-app/app/components/SummaryTitle.tsx
@@ -32,7 +32,6 @@ export function SummaryTitle(props: SummaryTitleProps): JSX.Element {
 
       <View style={tailwind("flex-row items-center")}>
         <NumberFormat
-          decimalScale={8}
           displayType="text"
           renderText={(value) => (
             <ThemedText

--- a/mobile-app/app/components/SummaryTitleV2.tsx
+++ b/mobile-app/app/components/SummaryTitleV2.tsx
@@ -51,7 +51,6 @@ export function SummaryTitleV2(props: ISummaryTitleProps): JSX.Element {
           )}
 
           <NumberFormat
-            decimalScale={8}
             displayType="text"
             renderText={(value) => (
               <ThemedTextV2

--- a/mobile-app/app/components/__snapshots__/InfoRow.test.tsx.snap
+++ b/mobile-app/app/components/__snapshots__/InfoRow.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`estimated fee info scanner should match snapshot of estimated fee 1`] =
       }
       testID="text_fee"
     >
-      100
+      100.00000000
     </Text>
     <Text
       style={
@@ -237,7 +237,7 @@ exports[`estimated fee info scanner should match snapshot of vault fee 1`] = `
       }
       testID="text_fee"
     >
-      100
+      100.00000000
     </Text>
     <Text
       style={

--- a/mobile-app/app/components/__snapshots__/NumberRow.test.tsx.snap
+++ b/mobile-app/app/components/__snapshots__/NumberRow.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`Number row should match snapshot for component suffix 1`] = `
             }
             testID="foo_test"
           >
-            100
+            100.00000000
           </Text>
         </Text>
       </View>
@@ -283,7 +283,7 @@ exports[`Number row should match snapshot for text suffix 1`] = `
             }
             testID="foo_test"
           >
-            100
+            100.00000000
           </Text>
           <Text>
              

--- a/mobile-app/app/screens/AppNavigator/screens/Auctions/components/BatchCard.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Auctions/components/BatchCard.tsx
@@ -97,7 +97,6 @@ export function BatchCard(props: BatchCardProps): JSX.Element {
               <NumberFormat
                 displayType="text"
                 prefix="$"
-                decimalScale={2}
                 renderText={(value: string) => (
                   <ThemedTextV2
                     light={tailwind("text-mono-light-v2-1000")}

--- a/mobile-app/app/screens/AppNavigator/screens/Auctions/components/BidHistoryItem.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Auctions/components/BidHistoryItem.tsx
@@ -48,9 +48,8 @@ export function BidHistoryItem({
             ` ${translate("components/BidHistory", "(Yours)")}`}
         </ThemedTextV2>
         <NumberFormat
-          value={bidAmount}
+          value={BigNumber(bidAmount).toFixed(8)}
           thousandSeparator
-          decimalScale={8}
           suffix={` ${loanDisplaySymbol}`}
           fixedDecimalScale
           displayType="text"

--- a/mobile-app/app/screens/AppNavigator/screens/Auctions/screens/AuctionDetailScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Auctions/screens/AuctionDetailScreen.tsx
@@ -190,7 +190,6 @@ export function AuctionDetailScreen(
           <NumberFormat
             displayType="text"
             prefix="$"
-            decimalScale={2}
             renderText={(value: string) => (
               <ThemedTextV2
                 light={tailwind("text-mono-light-v2-1000")}
@@ -209,7 +208,7 @@ export function AuctionDetailScreen(
               </ThemedTextV2>
             )}
             thousandSeparator
-            value={totalPrecisedCollateralsValue}
+            value={BigNumber(totalPrecisedCollateralsValue).toFixed(2)}
           />
         </View>
 

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/components/SwapRowTo.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/CompositeSwap/components/SwapRowTo.tsx
@@ -18,7 +18,6 @@ export function InstantSwapRowTo({
   return (
     <View style={tailwind("w-6/12 mr-2")}>
       <NumberFormat
-        decimalScale={8}
         displayType="text"
         thousandSeparator
         renderText={(val: string) => (

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/components/PoolPairCards/APRSection.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/components/PoolPairCards/APRSection.tsx
@@ -4,6 +4,7 @@ import { NumericFormat as NumberFormat } from "react-number-format";
 import { isEqual } from "lodash";
 import { tailwind } from "@tailwind";
 import { ThemedTextV2 } from "@components/themed";
+import BigNumber from "bignumber.js";
 
 interface APRSectionProps {
   label: string;
@@ -26,7 +27,6 @@ export const APRSection = memo((props: APRSectionProps): JSX.Element => {
         {props.label}
       </ThemedTextV2>
       <NumberFormat
-        decimalScale={props.value.decimalScale}
         displayType="text"
         renderText={(value) => (
           <ThemedTextV2
@@ -40,7 +40,7 @@ export const APRSection = memo((props: APRSectionProps): JSX.Element => {
         )}
         thousandSeparator
         suffix={props.value.suffix}
-        value={props.value.text}
+        value={BigNumber(props.value.text).toFixed(props.value.decimalScale)}
       />
     </View>
   );

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/components/PoolPairCards/InfoSection.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/components/PoolPairCards/InfoSection.tsx
@@ -146,7 +146,6 @@ function PoolPairInfoLine({
       </ThemedText>
       <View style={tailwind("items-end")}>
         <NumberFormat
-          decimalScale={value.decimalScale}
           displayType="text"
           renderText={(textValue) => (
             <ThemedText
@@ -169,7 +168,7 @@ function PoolPairInfoLine({
           thousandSeparator
           suffix={value.suffix}
           prefix={value.prefix}
-          value={value.text}
+          value={BigNumber(value.text).toFixed(value.decimalScale)}
         />
         {usdValue !== undefined && (
           <ActiveUSDValue

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/components/PoolPairCards/PoolSharesSection.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/components/PoolPairCards/PoolSharesSection.tsx
@@ -13,7 +13,6 @@ export function PoolSharesSection(props: PoolSharesSectionProps): JSX.Element {
   return (
     <View style={tailwind("flex flex-col")}>
       <NumberFormat
-        decimalScale={8}
         displayType="text"
         renderText={(textValue) => (
           <ThemedTextV2
@@ -27,7 +26,6 @@ export function PoolSharesSection(props: PoolSharesSectionProps): JSX.Element {
         value={props.walletTokenAmount.toFixed(8)}
       />
       <NumberFormat
-        decimalScale={2}
         displayType="text"
         renderText={(textValue) => (
           <ThemedTextV2

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/VaultDetail/components/CollateralsTab.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/VaultDetail/components/CollateralsTab.tsx
@@ -125,7 +125,6 @@ function CollateralCard(props: CollateralCardProps): JSX.Element {
         <NumberFormat
           value={prices.vaultShare?.toFixed(2)}
           thousandSeparator
-          decimalScale={2}
           displayType="text"
           suffix="%"
           renderText={(val: string) => (
@@ -147,7 +146,6 @@ function CollateralCard(props: CollateralCardProps): JSX.Element {
             <NumberFormat
               value={props.amount?.toFixed(8)}
               thousandSeparator
-              decimalScale={8}
               displayType="text"
               suffix={` ${props.displaySymbol}`}
               renderText={(val: string) => (

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/VaultDetail/components/VaultDetailCollateralsRow.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/VaultDetail/components/VaultDetailCollateralsRow.tsx
@@ -239,7 +239,6 @@ function CollateralCard(props: CollateralCardProps): JSX.Element {
               <NumberFormat
                 value={props.amount?.toFixed(8)}
                 thousandSeparator
-                decimalScale={8}
                 displayType="text"
                 renderText={(val: string) => (
                   <ThemedTextV2
@@ -270,7 +269,6 @@ function CollateralCard(props: CollateralCardProps): JSX.Element {
               <NumberFormat
                 value={prices.vaultShare?.toFixed(2)}
                 thousandSeparator
-                decimalScale={2}
                 displayType="text"
                 suffix="%"
                 renderText={(val: string) => (

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/VaultDetail/components/VaultDetailStatus.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/VaultDetail/components/VaultDetailStatus.tsx
@@ -115,7 +115,6 @@ export function VaultDetailStatus({
           <View style={tailwind("flex-col items-center")}>
             <NumberFormat
               value={new BigNumber(colRatio).toFixed(2)}
-              decimalScale={2}
               thousandSeparator
               displayType="text"
               suffix="%"
@@ -137,8 +136,7 @@ export function VaultDetailStatus({
               )}
             />
             <NumberFormat
-              value={nextColRatio?.toFixed(2) ?? 0}
-              decimalScale={2}
+              value={nextColRatio?.toFixed(2) ?? BigNumber(0).toFixed(2)}
               thousandSeparator
               displayType="text"
               suffix="%"

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/AddOrRemoveCollateralForm.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/AddOrRemoveCollateralForm.tsx
@@ -270,7 +270,6 @@ export const AddOrRemoveCollateralForm = memo(
           >
             <NumberFormat
               value={collateralFactor.toFixed(2)}
-              decimalScale={2}
               displayType="text"
               suffix={`% ${translate(
                 "components/AddOrRemoveCollateralForm",
@@ -348,7 +347,6 @@ export const AddOrRemoveCollateralForm = memo(
                     activePrice.multipliedBy(available)
                   )}
                   thousandSeparator
-                  decimalScale={2}
                   displayType="text"
                   prefix="$"
                   renderText={(val: string) => (
@@ -393,7 +391,6 @@ export const AddOrRemoveCollateralForm = memo(
               <NumberFormat
                 value={requiredTokensShare.toFixed(2)}
                 thousandSeparator
-                decimalScale={2}
                 displayType="text"
                 suffix="%"
                 renderText={(val: string) => (
@@ -456,9 +453,8 @@ export const AddOrRemoveCollateralForm = memo(
                 </ThemedText>
               ) : (
                 <NumberFormat
-                  value={vaultValue}
+                  value={BigNumber(vaultValue).toFixed(2)}
                   thousandSeparator
-                  decimalScale={2}
                   displayType="text"
                   suffix="%"
                   renderText={(val: string) => (
@@ -496,7 +492,6 @@ export const AddOrRemoveCollateralForm = memo(
             </ThemedText>
           ) : (
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               suffix="%"
               renderText={(val: string) => (

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/CollateralizationRatio.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/CollateralizationRatio.tsx
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { ThemedText, ThemedTextV2 } from "@components/themed";
+import { ThemedTextV2 } from "@components/themed";
 import { translate } from "@translations";
 import { NumericFormat as NumberFormat } from "react-number-format";
 import { tailwind } from "@tailwind";
@@ -35,7 +35,6 @@ export function CollateralizationRatio(
   return (
     <NumberFormat
       value={props.colRatio.toFixed(2)}
-      decimalScale={2}
       suffix="%"
       displayType="text"
       thousandSeparator

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/CollateralizationRatioDisplay.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/CollateralizationRatioDisplay.tsx
@@ -108,7 +108,6 @@ function CollateralizationRatioText(props: {
       ) : (
         <NumberFormat
           value={new BigNumber(props.colRatio).toFixed(2)}
-          decimalScale={2}
           thousandSeparator
           displayType="text"
           suffix="%"
@@ -144,8 +143,7 @@ function MinAndNextRatioText(props: {
           {translate("components/CollateralizationRatioDisplay", "Min:")}
         </ThemedText>
         <NumberFormat
-          value={props.minColRatio}
-          decimalScale={2}
+          value={BigNumber(props.minColRatio).toFixed(2)}
           thousandSeparator
           displayType="text"
           suffix="%"
@@ -180,7 +178,6 @@ function MinAndNextRatioText(props: {
           </ThemedText>
           <NumberFormat
             value={new BigNumber(props.nextColRatio).toFixed(2)}
-            decimalScale={2}
             thousandSeparator
             displayType="text"
             prefix="~"

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/CollateralizationRatioDisplayV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/CollateralizationRatioDisplayV2.tsx
@@ -90,7 +90,6 @@ export function CollateralizationRatioDisplayV2(
         ) : (
           <NumberFormat
             value={new BigNumber(props.collateralizationRatio).toFixed(2)}
-            decimalScale={2}
             thousandSeparator
             displayType="text"
             suffix="%"

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/CollateralizationRatioRow.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/CollateralizationRatioRow.tsx
@@ -2,6 +2,7 @@ import { View } from "@components";
 import { BottomSheetInfo } from "@components/BottomSheetInfo";
 import { ThemedText, ThemedView } from "@components/themed";
 import { tailwind } from "@tailwind";
+import BigNumber from "bignumber.js";
 
 import { NumericFormat as NumberFormat } from "react-number-format";
 import {
@@ -72,8 +73,7 @@ export function CollateralizationRatioValue(
 
   return (
     <NumberFormat
-      value={props.value}
-      decimalScale={2}
+      value={BigNumber(props.value).toFixed(2)}
       thousandSeparator
       displayType="text"
       suffix="%"

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/LoanCards.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/LoanCards.tsx
@@ -40,6 +40,7 @@ import {
   SkeletonLoaderScreen,
 } from "@components/SkeletonLoader";
 import { BottomSheetTokenListHeader } from "@components/BottomSheetTokenListHeader";
+import { ListRenderItemInfo } from "@shopify/flash-list";
 import {
   LoansTokensSortRow,
   LoansTokensSortType,
@@ -60,7 +61,6 @@ interface LoanCardsProps {
   sortRef?: React.Ref<any>;
 }
 export interface LoanCardOptions {
-  loanTokenId: string;
   symbol: string;
   displaySymbol: string;
   price?: ActivePrice;
@@ -473,10 +473,7 @@ export function LoanCards(props: LoanCardsProps): JSX.Element {
           renderItem={({
             item,
             index,
-          }: {
-            item: LoanToken;
-            index: number;
-          }): JSX.Element => {
+          }: ListRenderItemInfo<LoanToken>): JSX.Element => {
             return (
               <View style={{ flexBasis: "98%" }}>
                 <LoanCard
@@ -484,7 +481,6 @@ export function LoanCards(props: LoanCardsProps): JSX.Element {
                   displaySymbol={item.token.displaySymbol}
                   interestRate={item.interest}
                   price={item.activePrice}
-                  loanTokenId={item.tokenId}
                   onPress={() => {
                     onBorrowPress(item);
                   }}
@@ -560,7 +556,6 @@ function LoanCard({
         <MemoizedLoanIcon testID={testID} displaySymbol={displaySymbol} />
       </View>
       <NumberFormat
-        decimalScale={2}
         thousandSeparator
         displayType="text"
         renderText={(value: string) => (
@@ -576,10 +571,9 @@ function LoanCard({
             </ThemedText>
           </View>
         )}
-        value={currentPrice}
+        value={BigNumber(currentPrice).toFixed(2)}
       />
       <NumberFormat
-        decimalScale={2}
         thousandSeparator
         displayType="text"
         renderText={(value: string) => (
@@ -594,7 +588,7 @@ function LoanCard({
             })}
           </ThemedTextV2>
         )}
-        value={interestRate}
+        value={BigNumber(interestRate).toFixed(2)}
         suffix="%"
       />
       {!isBorrowHidden && (

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/LoanPercentage.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/LoanPercentage.tsx
@@ -43,7 +43,6 @@ export function LoanPercentage({
           "You are paying"
         )} `}</ThemedText>
         <NumberFormat
-          decimalScale={2}
           displayType="text"
           renderText={(value) => (
             <ThemedText
@@ -62,7 +61,7 @@ export function LoanPercentage({
                   .dividedBy(outstandingBalanceInPaymentToken)
                   .multipliedBy(100)
                   .toFixed(2)
-              : "0"
+              : BigNumber("0").toFixed(2)
           }
         />
         <ThemedText {...textStyle}>{` ${translate(

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/NumberRowWithConversion.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/NumberRowWithConversion.tsx
@@ -6,6 +6,7 @@ import {
   BottomSheetAlertInfo,
   BottomSheetInfo,
 } from "@components/BottomSheetInfo";
+import BigNumber from "bignumber.js";
 
 type INumberRowProps = React.PropsWithChildren<ViewProps> &
   NumberRowWithConversionProps;
@@ -62,7 +63,6 @@ export function NumberRowWithConversion(props: INumberRowProps): JSX.Element {
 
       <View style={tailwind("flex-1 flex-col justify-end flex-wrap items-end")}>
         <NumberFormat
-          decimalScale={8}
           displayType="text"
           prefix={props.rhs.prefix}
           renderText={(val: string) => (
@@ -95,12 +95,11 @@ export function NumberRowWithConversion(props: INumberRowProps): JSX.Element {
             </Text>
           )}
           thousandSeparator
-          value={props.rhs.value}
+          value={BigNumber(props.rhs.value).toFixed(8)}
         />
 
         {props.rhsConversion !== undefined && (
           <NumberFormat
-            decimalScale={8}
             displayType="text"
             prefix={props.rhsConversion.prefix}
             renderText={(val: string) => (
@@ -151,7 +150,7 @@ export function NumberRowWithConversion(props: INumberRowProps): JSX.Element {
               </Text>
             )}
             thousandSeparator
-            value={props.rhsConversion.value}
+            value={BigNumber(props.rhsConversion.value).toFixed(8)}
           />
         )}
       </View>

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/VaultCardStatus.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/VaultCardStatus.tsx
@@ -120,7 +120,6 @@ export function VaultCardStatus({
           ) : (
             <NumberFormat
               value={new BigNumber(colRatio).toFixed(2)}
-              decimalScale={2}
               thousandSeparator
               displayType="text"
               suffix="%"

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/VaultSectionTextRowV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/VaultSectionTextRowV2.tsx
@@ -5,6 +5,7 @@ import { tailwind } from "@tailwind";
 import { NumericFormat as NumberFormat } from "react-number-format";
 
 import { View, ViewProps } from "react-native";
+import BigNumber from "bignumber.js";
 
 type IVaultSectionTextProps = React.PropsWithChildren<ViewProps> &
   VaultSectionTextProps;
@@ -32,7 +33,6 @@ export function VaultSectionTextRowV2(
         {props.lhs}
       </ThemedTextV2>
       <NumberFormat
-        decimalScale={8}
         displayType="text"
         prefix={props.prefix}
         renderText={(val: string) => (
@@ -59,7 +59,7 @@ export function VaultSectionTextRowV2(
           </>
         )}
         thousandSeparator
-        value={props.value}
+        value={BigNumber(props.value).toFixed(8)}
       />
     </View>
   );

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/__snapshots__/VaultCard.test.tsx.snap
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/__snapshots__/VaultCard.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`Vault card should match snapshot of active vault 1`] = `
               }
               testID="vault_max_loan_amount_amount"
             >
-              $0.00
+              $0.00000000
             </Text>
           </View>
           <View
@@ -539,7 +539,7 @@ exports[`Vault card should match snapshot of at-risk vault 1`] = `
               }
               testID="vault_max_loan_amount_amount"
             >
-              $0.00
+              $0.00000000
             </Text>
           </View>
           <View
@@ -929,7 +929,7 @@ exports[`Vault card should match snapshot of healthy vault 1`] = `
               }
               testID="vault_max_loan_amount_amount"
             >
-              $0.00
+              $0.00000000
             </Text>
           </View>
           <View

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/screens/AddOrRemoveCollateralScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/screens/AddOrRemoveCollateralScreen.tsx
@@ -20,7 +20,6 @@ import {
   getPrecisedCurrencyValue,
   getPrecisedTokenValue,
 } from "@screens/AppNavigator/screens/Auctions/helpers/precision-token-value";
-import { useFeatureFlagContext } from "@contexts/FeatureFlagContext";
 import {
   AmountButtonTypes,
   TransactionCard,
@@ -108,7 +107,6 @@ export function AddOrRemoveCollateralScreen({ route }: Props): JSX.Element {
   );
 
   const navigation = useNavigation<NavigationProp<LoanParamList>>();
-  const { isFeatureAvailable } = useFeatureFlagContext();
 
   const TOAST_DURATION = 2000;
   const toast = useToast();
@@ -834,7 +832,6 @@ function TotalTokenCollateralRow(props: {
             style={tailwind("flex flex-row justify-end flex-wrap items-center")}
           >
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               suffix={` ${props.symbol}`}
               renderText={(val: string) => (

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/screens/EditCollateralScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/screens/EditCollateralScreen.tsx
@@ -34,7 +34,6 @@ import {
 } from "@defichain/whale-api-client/dist/api/loan";
 import { IconButton } from "@components/IconButton";
 import { BottomSheetTokenListHeader } from "@components/BottomSheetTokenListHeader";
-import { tokensSelector } from "@store/wallet";
 import { getCollateralPrice } from "@screens/AppNavigator/screens/Loans/hooks/CollateralPrice";
 import {
   useVaultStatus,
@@ -77,10 +76,6 @@ export function EditCollateralScreen({
   const [activeVault, setActiveVault] = useState<LoanVaultActive>();
   const dispatch = useAppDispatch();
   const canUseOperations = useLoanOperations(activeVault?.state);
-
-  const tokens = useSelector((state: RootState) =>
-    tokensSelector(state.wallet)
-  );
 
   const { vaults } = useSelector((state: RootState) => state.loans);
   const { collateralTokens } = useCollateralTokenList();
@@ -418,9 +413,8 @@ function CollateralCard(props: CollateralCardProps): JSX.Element {
           <CardLabel text="Collateral amount (USD)" />
           <View style={tailwind("mt-0.5")}>
             <NumberFormat
-              value={collateral.amount}
+              value={BigNumber(collateral.amount).toFixed(8)}
               thousandSeparator
-              decimalScale={8}
               displayType="text"
               suffix={` ${collateral.displaySymbol}`}
               renderText={(val: string) => (
@@ -446,7 +440,6 @@ function CollateralCard(props: CollateralCardProps): JSX.Element {
           <NumberFormat
             value={prices.vaultShare.toFixed(2)}
             thousandSeparator
-            decimalScale={2}
             displayType="text"
             suffix="%"
             renderText={(val: string) => (

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/screens/PaybackLoanScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/screens/PaybackLoanScreen.tsx
@@ -346,7 +346,6 @@ export function PaybackLoanScreen({ navigation, route }: Props): JSX.Element {
         {!routeParams.isPaybackDUSDUsingCollateral && (
           <View style={tailwind("mt-2 mx-5")}>
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               renderText={(value) => (
                 <ThemedTextV2

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/components/TokenAmountText.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/components/TokenAmountText.tsx
@@ -25,7 +25,6 @@ export function TokenAmountText({
 
   return (
     <NumberFormat
-      decimalScale={8}
       displayType="text"
       renderText={(value) => (
         <View style={tailwind("flex flex-1")}>

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/components/TokenBreakdownDetailsV2.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/components/TokenBreakdownDetailsV2.tsx
@@ -23,8 +23,6 @@ import { PortfolioButtonGroupTabKey } from "./TotalPortfolio";
 
 interface TokenBreakdownDetailProps {
   hasFetchedToken: boolean;
-  lockedAmount: BigNumber;
-  lockedValue: BigNumber;
   availableAmount: BigNumber;
   availableValue: BigNumber;
   dfiUtxo?: WalletToken;
@@ -346,10 +344,9 @@ function DFITokenBreakDownDetailsRow({
         <NumberFormat
           value={
             percentageValue.isNaN()
-              ? new BigNumber("0").toFixed(8)
-              : percentageValue.toFixed(8)
+              ? new BigNumber("0").toFixed(2)
+              : percentageValue.toFixed(2)
           }
-          decimalScale={2}
           displayType="text"
           renderText={(value) => (
             <ThemedTextV2

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/components/TokenBreakdownPercentage.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/components/TokenBreakdownPercentage.tsx
@@ -11,7 +11,6 @@ import { BalanceText } from "./BalanceText";
 interface TokenBreakdownPercentageProps {
   lockedAmount: BigNumber;
   displaySymbol: string;
-  symbol: string;
   testID: string;
 }
 
@@ -72,7 +71,6 @@ function LockedPercentageItem(props: LockedPercentageItemProps): JSX.Element {
       <NumberFormat
         value={props.lockedAmount.toFixed(8)}
         thousandSeparator
-        decimalScale={8}
         displayType="text"
         suffix={` ${props.displaySymbol}`}
         renderText={(value) => (

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/ConvertScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/ConvertScreen.tsx
@@ -258,7 +258,6 @@ export function ConvertScreen(props: Props): JSX.Element {
             </ThemedTextV2>
             {inlineTextStatus === InlineTextStatus.Default && (
               <NumberFormat
-                decimalScale={8}
                 displayType="text"
                 suffix={` ${getDisplayUnit(sourceToken.unit)}`}
                 renderText={(value) => (
@@ -436,7 +435,6 @@ function ConversionResultCard(props: {
           })}`}
         </ThemedTextV2>
         <NumberFormat
-          decimalScale={8}
           displayType="text"
           renderText={(value) => (
             <ThemedTextV2
@@ -468,7 +466,6 @@ function ConversionResultCard(props: {
           })}`}
         </ThemedTextV2>
         <NumberFormat
-          decimalScale={8}
           displayType="text"
           renderText={(value) => (
             <ThemedTextV2
@@ -481,7 +478,7 @@ function ConversionResultCard(props: {
             </ThemedTextV2>
           )}
           thousandSeparator
-          value={props.totalTargetAmount}
+          value={BigNumber(props.totalTargetAmount).toFixed(8)}
         />
       </ThemedViewV2>
     </ThemedViewV2>

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/GetDFIScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/GetDFIScreen.tsx
@@ -268,7 +268,6 @@ function DFIOraclePrice(): JSX.Element {
       <NumberFormat
         displayType="text"
         prefix="$"
-        decimalScale={2}
         renderText={(val: string) => (
           <ThemedTextV2
             light={tailwind("text-mono-light-v2-900")}

--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/TokenDetailScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/screens/TokenDetailScreen.tsx
@@ -31,10 +31,6 @@ import { InfoTextLinkV2 } from "@components/InfoTextLink";
 import { ThemedTouchableListItem } from "@components/themed/ThemedTouchableListItem";
 import { PortfolioParamList } from "../PortfolioNavigator";
 import { ConversionMode } from "./ConvertScreen";
-import {
-  LockedBalance,
-  useTokenLockedBalance,
-} from "../hooks/TokenLockedBalance";
 import { useTokenPrice } from "../hooks/TokenPrice";
 import { useDenominationCurrency } from "../hooks/PortfolioCurrency";
 import { TokenBreakdownDetailsV2 } from "../components/TokenBreakdownDetailsV2";
@@ -48,7 +44,6 @@ interface TokenActionItems {
   onPress: () => void;
   testID: string;
   iconType: IconType;
-  border?: boolean;
   isLast?: boolean;
 }
 
@@ -111,13 +106,6 @@ export function TokenDetailScreen({ route, navigation }: Props): JSX.Element {
   const { denominationCurrency } = useDenominationCurrency();
   const { hasFetchedToken } = useSelector((state: RootState) => state.wallet);
   const { getTokenPrice } = useTokenPrice(denominationCurrency); // input based on selected denomination from portfolio tab
-  const lockedToken = (useTokenLockedBalance({
-    displaySymbol: "DFI",
-    denominationCurrency: denominationCurrency,
-  }) as LockedBalance) ?? {
-    amount: new BigNumber(0),
-    tokenValue: new BigNumber(0),
-  };
   const DFIUnified = useSelector((state: RootState) =>
     unifiedDFISelector(state.wallet)
   );
@@ -197,8 +185,6 @@ export function TokenDetailScreen({ route, navigation }: Props): JSX.Element {
       <View style={tailwind("p-5 pb-12")}>
         <TokenBreakdownDetailsV2
           hasFetchedToken={hasFetchedToken}
-          lockedAmount={lockedToken.amount}
-          lockedValue={lockedToken.tokenValue}
           availableAmount={new BigNumber(DFIUnified.amount)}
           availableValue={availableValue}
           testID="dfi"
@@ -453,7 +439,6 @@ function TokenSummary(props: {
         ) : (
           <View style={[tailwind("flex-col"), { marginLeft: "auto" }]}>
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               renderText={(value) => (
                 <ThemedTextV2
@@ -467,7 +452,6 @@ function TokenSummary(props: {
               value={new BigNumber(props.token.amount).toFixed(8)}
             />
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               prefix={
                 denominationCurrency === PortfolioButtonGroupTabKey.USDT

--- a/mobile-app/app/screens/AppNavigator/screens/Settings/screens/NetworkDetails.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Settings/screens/NetworkDetails.tsx
@@ -17,6 +17,7 @@ import { translate } from "@translations";
 import { TextRow } from "@components/TextRow";
 import { NumberRow } from "@components/NumberRow";
 import { useDeFiScanContext } from "@shared-contexts/DeFiScanContext";
+import BigNumber from "bignumber.js";
 
 export function NetworkDetails(): JSX.Element {
   const { network } = useNetworkContext();
@@ -136,7 +137,6 @@ function BlocksInfoRow({ blockCount }: { blockCount?: number }): JSX.Element {
         >
           <View style={tailwind("flex-row items-center")}>
             <NumberFormat
-              decimalScale={8}
               displayType="text"
               renderText={(val: string) => (
                 <ThemedText
@@ -151,7 +151,9 @@ function BlocksInfoRow({ blockCount }: { blockCount?: number }): JSX.Element {
                 </ThemedText>
               )}
               thousandSeparator
-              value={blockCount}
+              value={
+                blockCount ? blockCount.toFixed(8) : BigNumber("0").toFixed(8)
+              }
             />
             <View style={tailwind("ml-2 flex-grow-0 justify-center")}>
               <ThemedIcon

--- a/mobile-app/app/screens/AppNavigator/screens/Settings/screens/__snapshots__/NetworkDetails.test.tsx.snap
+++ b/mobile-app/app/screens/AppNavigator/screens/Settings/screens/__snapshots__/NetworkDetails.test.tsx.snap
@@ -506,7 +506,7 @@ exports[`NetworkDetails <NetworkDetails /> should render components 1`] = `
               }
               testID="network_details_block_height"
             >
-              2,000
+              2,000.00000000
             </Text>
             <View
               style={
@@ -667,7 +667,7 @@ exports[`NetworkDetails <NetworkDetails /> should render components 1`] = `
                 }
                 testID="network_details_total_masternodes"
               >
-                10
+                10.00000000
               </Text>
             </Text>
           </View>

--- a/mobile-app/app/screens/AppNavigator/screens/Settings/screens/__snapshots__/NetworkSelectionScreen.test.tsx.snap
+++ b/mobile-app/app/screens/AppNavigator/screens/Settings/screens/__snapshots__/NetworkSelectionScreen.test.tsx.snap
@@ -843,7 +843,7 @@ exports[`onboarding network selection screen should render 1`] = `
                 }
                 testID="network_details_total_masternodes"
               >
-                10
+                10.00000000
               </Text>
             </View>
           </View>

--- a/mobile-app/app/screens/AppNavigator/screens/Transactions/TransactionsScreen.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Transactions/TransactionsScreen.tsx
@@ -16,7 +16,12 @@ import { tailwind } from "@tailwind";
 import { translate } from "@translations";
 import dayjs from "dayjs";
 import { useEffect, useRef, useState } from "react";
-import { RefreshControl, TouchableOpacity, View } from "react-native";
+import {
+  ListRenderItemInfo,
+  RefreshControl,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { NumericFormat as NumberFormat } from "react-number-format";
 import { useSelector } from "react-redux";
 import {
@@ -26,6 +31,7 @@ import {
   ThemedTouchableOpacity,
 } from "@components/themed";
 import { PortfolioParamList } from "@screens/AppNavigator/screens/Portfolio/PortfolioNavigator";
+import BigNumber from "bignumber.js";
 import { EmptyTransaction } from "./EmptyTransaction";
 import { activitiesToViewModel, VMTransaction } from "./screens/stateProcessor";
 
@@ -135,7 +141,7 @@ export function TransactionsScreen(): JSX.Element {
           refreshing={loadingState === "loadingMore"}
         />
       }
-      renderItem={({ item, index }: { item: VMTransaction; index: number }) => (
+      renderItem={({ item, index }: ListRenderItemInfo<VMTransaction>) => (
         <TransactionRow index={index} item={item} navigation={navigation} />
       )}
       style={tailwind("w-full")}
@@ -192,7 +198,6 @@ function TransactionRow({
 
         <View style={tailwind("flex-row ml-3 w-32 justify-end items-center")}>
           <NumberFormat
-            decimalScale={8}
             displayType="text"
             renderText={(value) => (
               <ThemedText
@@ -204,7 +209,7 @@ function TransactionRow({
               </ThemedText>
             )}
             thousandSeparator
-            value={amount}
+            value={BigNumber(amount).toFixed(8)}
           />
 
           <View style={tailwind("ml-2 items-start")}>

--- a/mobile-app/app/screens/WalletNavigator/screens/CreateWallet/__snapshots__/OnboardingNetworkSelectScreen.test.tsx.snap
+++ b/mobile-app/app/screens/WalletNavigator/screens/CreateWallet/__snapshots__/OnboardingNetworkSelectScreen.test.tsx.snap
@@ -817,7 +817,7 @@ exports[`onboarding network selection screen should render 1`] = `
               }
               testID="network_details_total_masternodes"
             >
-              10
+              10.00000000
             </Text>
           </View>
         </View>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
This PR is to remove all decimalScale in NumberFormat and use BigNumber(value).toFixed()
this is because the decimalScale prop cant be customized and always round the values down
using BigNumber(value).toFixed() will enable consistent rounding and decimal places

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
1. Removed decimalScale in all NumberFormat. For NumberFormats with different decimalScale dp and value dp toFixed() will be using the smaller value dp 
2. fix linting issues by removing unused props/variables and adding ListRenderItemInfo<> to resolve FlatList and FlashList prop type error

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
