### PR TITLE
fix(ui-ux): DEX / Loans Inconsistent font size for buttons

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Dex/components/DexActionButton.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/components/DexActionButton.tsx
@@ -34,7 +34,7 @@ export function DexActionButton({
       <ThemedTextV2
         light={tailwind("text-mono-light-v2-900")}
         dark={tailwind("text-mono-dark-v2-900")}
-        style={tailwind("font-semibold-v2 text-sm text-center")}
+        style={tailwind("font-semibold-v2 text-xs text-center")}
         testID={testID}
       >
         {label}

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/components/PoolPairCards/PoolPairCards.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/components/PoolPairCards/PoolPairCards.tsx
@@ -54,11 +54,8 @@ interface PoolPairCardProps {
   onSwap: (data: PoolPairData) => void;
   onPress: (id: string) => void;
   type: "your" | "available";
-  setIsSearching: (isSearching: boolean) => void;
   searchString: string;
   showSearchInput?: boolean;
-  expandedCardIds: string[];
-  setExpandedCardIds: (ids: string[]) => void;
   topLiquidityPairs: Array<DexItem<PoolPairData>>;
   newPoolsPairs: Array<DexItem<PoolPairData>>;
   activeButtonGroup: ButtonGroupTabKey;
@@ -390,7 +387,7 @@ function AvailablePool(props: AvailablePoolProps): JSX.Element {
           label={translate("screens/DexScreen", "Swap")}
           onPress={props.onSwap}
           testID={`composite_swap_button_${props.pair.id}`}
-          style={tailwind("py-2 px-3")}
+          style={tailwind("py-2 px-4")}
           disabled={!props.status}
         />
       </View>

--- a/mobile-app/app/screens/AppNavigator/screens/Dex/components/SwapButton.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Dex/components/SwapButton.tsx
@@ -11,7 +11,7 @@ export function SwapButton(): JSX.Element {
     <ThemedTouchableOpacityV2
       light={tailwind("bg-mono-light-v2-1000")}
       dark={tailwind("bg-mono-dark-v2-1000")}
-      style={tailwind("py-2 px-5 rounded-2xl-v2")}
+      style={tailwind("py-2 px-4 rounded-2xl-v2")}
       onPress={() =>
         navigation.navigate({
           name: "CompositeSwap",
@@ -23,7 +23,7 @@ export function SwapButton(): JSX.Element {
       <ThemedTextV2
         light={tailwind("text-mono-light-v2-100")}
         dark={tailwind("text-mono-dark-v2-100")}
-        style={tailwind("font-semibold-v2 text-sm")}
+        style={tailwind("font-semibold-v2 text-xs")}
         testID="composite_swap"
       >
         {translate("screens/DexScreen", "Swap")}

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/VaultBanner.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/VaultBanner.tsx
@@ -125,8 +125,8 @@ export function VaultBanner({
             </ThemedTextV2>
             {buttonLabel !== "" && (
               <ButtonV2
-                customButtonStyle="py-2 px-3"
-                customTextStyle="text-sm"
+                customButtonStyle="py-2 px-4"
+                customTextStyle="text-xs"
                 styleProps="mt-3"
                 label={translate("components/VaultCard", buttonLabel)}
                 onPress={onButtonPress}

--- a/mobile-app/app/screens/AppNavigator/screens/Loans/components/VaultCardStatus.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Loans/components/VaultCardStatus.tsx
@@ -151,7 +151,7 @@ export function VaultCardStatus({
               vaultStatus === VaultStatus.Halted ? undefined : onButtonPressed
             }
             style={tailwind(
-              "flex-wrap border-0 rounded-full self-center px-3 py-1 mt-4"
+              "flex-wrap border-0 rounded-full self-center px-4 py-2 mt-2"
             )}
             dark={tailwind("bg-mono-dark-v2-1000", {
               "bg-gray-600": vaultStatus === VaultStatus.Halted,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
This PR is to fix the inconsistent font sizes and paddings for buttons in DEX and Loans screens. 
Regarding button text styles, it changed from font size of 14 and line height of 20 to 12 and 16 respectively.
For padding styles, padding left and right was changed to 16px.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [ ] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
