### PR TITLE
feature(token api): recursively get all tokens

### DIFF
--- a/shared/store/wallet.ts
+++ b/shared/store/wallet.ts
@@ -175,7 +175,7 @@ export const fetchTokens = createAsyncThunk(
     utxoBalance: string;
   }> => {
     const tokens = await client.address.listToken(address, size);
-    const allTokens = await getAllTokens(client, size);
+    const allTokens = await getAllTokens(client, 999);
     const utxoBalance = await client.address.getBalance(address);
     return {
       tokens,
@@ -273,6 +273,7 @@ const getAllTokens = async (
   client: WhaleApiClient,
   size: number
 ): Promise<TokenData[]> => {
+  const sizeLimit = 200;
   const allTokens: TokenData[] = [];
   let hasNext = false;
   let next;
@@ -285,7 +286,7 @@ const getAllTokens = async (
     allTokens.push(..._allTokens);
     hasNext = _allTokens.hasNext;
     next = _allTokens.nextToken;
-  } while (hasNext);
+  } while (hasNext && size > sizeLimit);
   return allTokens;
 };
 

--- a/shared/store/wallet.ts
+++ b/shared/store/wallet.ts
@@ -1,4 +1,4 @@
-import { WhaleApiClient } from "@defichain/whale-api-client";
+import { ApiPagedResponse, WhaleApiClient } from "@defichain/whale-api-client";
 import { AddressToken } from "@defichain/whale-api-client/dist/api/address";
 import {
   AllSwappableTokensResult,
@@ -175,12 +175,12 @@ export const fetchTokens = createAsyncThunk(
     utxoBalance: string;
   }> => {
     const tokens = await client.address.listToken(address, size);
-    const allTokens = await client.tokens.list(size);
+    const allTokens = await getAllTokens(client, size);
     const utxoBalance = await client.address.getBalance(address);
     return {
       tokens,
-      utxoBalance,
       allTokens,
+      utxoBalance,
     };
   }
 );
@@ -265,6 +265,29 @@ export const wallet = createSlice({
     );
   },
 });
+
+/**
+ * Recursively get all tokens based on pagination info from ApiPagedResponse class
+ */
+const getAllTokens = async (
+  client: WhaleApiClient,
+  size: number
+): Promise<TokenData[]> => {
+  const allTokens: TokenData[] = [];
+  let hasNext = false;
+  let next;
+
+  do {
+    const _allTokens: ApiPagedResponse<TokenData> = await client.tokens.list(
+      size,
+      next
+    );
+    allTokens.push(..._allTokens);
+    hasNext = _allTokens.hasNext;
+    next = _allTokens.nextToken;
+  } while (hasNext);
+  return allTokens;
+};
 
 const rawTokensSelector = createSelector(
   (state: WalletState) => state.tokens,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:
- As titled, to bypass size limitation imposed on whale.
- Currently calling `..tokens?size=201` or any size that is >200 will always return only 200 records, this PR will recursively get all token 

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [ ] No console errors on web
- [x] Tested on Light mode and Dark mode*
- [ ] Your UI implementation visually matched the rendered design*
- [ ] Unit tests*
- [ ] Added e2e tests*
- [ ] Added translations*

<!-- 
* If applicable 
-->
