### PR TITLE
fix(ui-ux): cfp only allow seed wallet address

### DIFF
--- a/mobile-app/app/screens/AppNavigator/screens/Portfolio/components/AddressRow.tsx
+++ b/mobile-app/app/screens/AppNavigator/screens/Portfolio/components/AddressRow.tsx
@@ -208,7 +208,7 @@ export function AddressRow({
               {/* TODO: Update with required error message also */}
               {!hasValidAddress && (
                 <ThemedTextV2
-                  style={tailwind("text-xs mt-2 ml-5 font-normal-v2")}
+                  style={tailwind("text-xs mt-2 mx-5 font-normal-v2")}
                   dark={tailwind("text-red-v2")}
                   light={tailwind("text-red-v2")}
                   testID="address_error_text"
@@ -226,7 +226,11 @@ export function AddressRow({
           required: true,
           validate: {
             isValidAddress: (address) =>
-              fromAddress(address, networkName) !== undefined,
+              fromAddress(address, networkName) !== undefined &&
+              (!onlyLocalAddress ||
+                jellyfishWalletAddress.includes(address) ||
+                (walletAddress !== undefined &&
+                  walletAddress[address] !== undefined)),
           },
         }}
       />

--- a/mobile-app/cypress/e2e/functional/wallet/portfolio/cfp_dfip.spec.ts
+++ b/mobile-app/cypress/e2e/functional/wallet/portfolio/cfp_dfip.spec.ts
@@ -131,6 +131,7 @@ context("QA-780-2: Wallet - Submit CFP", () => {
 
   it("should be able to key in amount", () => {
     cy.getByTestID("input_amount").type(CfpData.amount);
+    cy.getByTestID("cfp_continue_button").should("not.be.enabled");
   });
 
   it("should be able to key in cycles", () => {
@@ -145,6 +146,7 @@ context("QA-780-2: Wallet - Submit CFP", () => {
     cy.getByTestID("input_cycle_error").should("exist");
     cy.getByTestID("input_cycle").clear().type("2");
     cy.getByTestID("input_cycle_error").should("not.exist");
+    cy.getByTestID("cfp_continue_button").should("not.be.enabled");
   });
 
   it("should be able to check invalid receiving address", () => {
@@ -154,6 +156,7 @@ context("QA-780-2: Wallet - Submit CFP", () => {
       "Invalid address. Make sure the address is correct to avoid irrecoverable losses"
     );
     cy.getByTestID("address_input_clear_button").click();
+    cy.getByTestID("cfp_continue_button").should("not.be.enabled");
   });
 
   it("should verify confirm screen", () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
When submitting CFP, should only allow seed wallet address (local address), if not the continue button should be disabled. 
#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on iOS/Android device (e.g, No crashes, library supported etc.)
- [x] No console errors on web
- [x] Tested on Light mode and Dark mode\*
- [x] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*
- [ ] Added translations\*

<!--
* If applicable
-->
